### PR TITLE
boost->std::shared_ptr

### DIFF
--- a/DeveloperGuide.md
+++ b/DeveloperGuide.md
@@ -67,7 +67,7 @@ The C function that is called is as follows:
         if (!boost::filesystem::exists(file))
             return fileNotFound(file, __FILE__, __LINE__);
         try {
-            boost::shared_ptr<AcquisitionsContainer> 
+            std::shared_ptr<AcquisitionsContainer> 
                 acquisitions(new AcquisitionsFile(file));
             return sptrObjectHandle<AcquisitionsContainer>(acquisitions);
         }
@@ -76,7 +76,7 @@ The C function that is called is as follows:
 
 As can be seen from the above C source, the function checks if the acquisition data file exists, and if it does, creates an AcquisitionsContainer object of derived type AcquisitionsFile. The return value of this function, which ends up in `acq_data.handle`, is a C void pointer to a C++ object ObjectHandle that encapsulates a shared pointer to an AcquisitionsContainer object (cf. [Data handling](#Data_handling)). We note that AcquisitionsData and AcquisitionsFile types are part of extended Gadgetron functionality, the first layer above the Gadgetron engine, and the ObjectHandle type is part of the second layer. Finally, the constructor of AcquisitionsFile has the following line
 
-    dataset_ = boost::shared_ptr<ISMRMRD::Dataset>
+    dataset_ = std::shared_ptr<ISMRMRD::Dataset>
         (new ISMRMRD::Dataset(filename.c_str(), "/dataset"));
 
 showing that the acquisition data file is handled by the Dataset object of ISMRMRD library employed by Gadgetron engine.

--- a/src/iUtilities/data_handle.h
+++ b/src/iUtilities/data_handle.h
@@ -30,13 +30,13 @@ limitations under the License.
 
 #define NEW(T, X) T* X = new T
 #define CAST_PTR(T, X, Y) T* X = (T*)Y
-#define SPTR(Base, X, Object) boost::shared_ptr< Base > X(new Object)
+#define SPTR(Base, X, Object) std::shared_ptr< Base > X(new Object)
 #define NEW_SPTR(Base, X, Object) \
-	boost::shared_ptr< Base >* X = new boost::shared_ptr< Base >(new Object)
+	std::shared_ptr< Base >* X = new std::shared_ptr< Base >(new Object)
 #define NEW_SPTR_FROM_PTR(Object, X, P) \
-	boost::shared_ptr< Object >* X = new boost::shared_ptr< Object >(P)
+	std::shared_ptr< Object >* X = new std::shared_ptr< Object >(P)
 #define SPTR_FROM_HANDLE(Object, X, H) \
-boost::shared_ptr<Object> X = objectSptrFromHandle<Object>(H);
+std::shared_ptr<Object> X = objectSptrFromHandle<Object>(H);
 
 #define THROW(msg) throw LocalisedException(msg, __FILE__, __LINE__)
 #define CATCH \
@@ -138,17 +138,17 @@ template<class Base>
 class ObjectHandle : public anObjectHandle {
 public:
 	ObjectHandle(const ObjectHandle& obj) {
-		NEW(boost::shared_ptr<Base>, ptr_sptr);
-		*ptr_sptr = *(boost::shared_ptr<Base>*)obj.data();
+		NEW(std::shared_ptr<Base>, ptr_sptr);
+		*ptr_sptr = *(std::shared_ptr<Base>*)obj.data();
 		_data = (void*)ptr_sptr;
 		if (obj._status)
 			_status = new ExecutionStatus(*obj._status);
 		else
 			_status = 0;
 	}
-	ObjectHandle(const boost::shared_ptr<Base>& sptr,
+	ObjectHandle(const std::shared_ptr<Base>& sptr,
 		const ExecutionStatus* status = 0) {
-		NEW(boost::shared_ptr<Base>, ptr_sptr);
+		NEW(std::shared_ptr<Base>, ptr_sptr);
 		*ptr_sptr = sptr;
 		_data = (void*)ptr_sptr;
 		if (status)
@@ -157,7 +157,7 @@ public:
 			_status = 0;
 	}
 	virtual ~ObjectHandle() {
-		CAST_PTR(boost::shared_ptr<Base>, ptr_sptr, _data);
+		CAST_PTR(std::shared_ptr<Base>, ptr_sptr, _data);
 		delete _status;
 		_status = 0;
 		delete ptr_sptr;
@@ -165,7 +165,7 @@ public:
 	virtual anObjectHandle* copy() {
 		if (_data == 0)
 			THROW("zero data pointer cannot be dereferenced");
-		CAST_PTR(boost::shared_ptr<Base>, ptr_sptr, _data);
+		CAST_PTR(std::shared_ptr<Base>, ptr_sptr, _data);
 		if (!ptr_sptr->get())
 			THROW("zero object pointer cannot be dereferenced");
 		return new ObjectHandle<Base>(*ptr_sptr, _status);
@@ -184,7 +184,7 @@ newObjectHandle()
 
 template<class Base>
 static void*
-newObjectHandle(boost::shared_ptr<Base>* ptr_sptr)
+newObjectHandle(std::shared_ptr<Base>* ptr_sptr)
 {
 	ObjectHandle<Base>* ptr_handle = new ObjectHandle<Base>(*ptr_sptr);
 	delete ptr_sptr;
@@ -193,7 +193,7 @@ newObjectHandle(boost::shared_ptr<Base>* ptr_sptr)
 
 template<class T>
 void*
-sptrObjectHandle(boost::shared_ptr<T> sptr) {
+sptrObjectHandle(std::shared_ptr<T> sptr) {
 	ObjectHandle<T>* ptr_handle = new ObjectHandle<T>(sptr);
 	return (void*)ptr_handle;
 }
@@ -205,7 +205,7 @@ objectFromHandle(const void* h) {
 	void* ptr = handle->data();
 	if (ptr == 0)
 		THROW("zero data pointer cannot be dereferenced");
-	CAST_PTR(boost::shared_ptr<Object>, ptr_sptr, ptr);
+	CAST_PTR(std::shared_ptr<Object>, ptr_sptr, ptr);
 	if (!ptr_sptr->get())
 		THROW("zero object pointer cannot be dereferenced");
 	CAST_PTR(Object, ptr_object, ptr_sptr->get());
@@ -213,13 +213,13 @@ objectFromHandle(const void* h) {
 }
 
 template<class Object>
-boost::shared_ptr<Object>&
+std::shared_ptr<Object>&
 objectSptrFromHandle(const void* h) {
 	DataHandle* handle = (DataHandle*)h;
 	void* ptr = handle->data();
 	if (ptr == 0)
 		THROW("zero data pointer cannot be dereferenced");
-	CAST_PTR(boost::shared_ptr<Object>, ptr_sptr, ptr);
+	CAST_PTR(std::shared_ptr<Object>, ptr_sptr, ptr);
 	if (!ptr_sptr->get())
 		THROW("zero object pointer cannot be dereferenced");
 	return *ptr_sptr;
@@ -234,7 +234,7 @@ objectPtrFromHandle(const void* h) {
 	void* ptr = handle->data();
 	if (ptr == 0)
 		return 0;
-	CAST_PTR(boost::shared_ptr<Object>, ptr_sptr, ptr);
+	CAST_PTR(std::shared_ptr<Object>, ptr_sptr, ptr);
 	return ptr_sptr->get();
 }
 
@@ -244,7 +244,7 @@ objectFromHandle(const DataHandle* handle) {
 	void* ptr = handle->data();
 	if (ptr == 0)
 		THROW("zero data pointer cannot be dereferenced");
-	CAST_PTR(boost::shared_ptr<Base>, ptr_sptr, ptr);
+	CAST_PTR(std::shared_ptr<Base>, ptr_sptr, ptr);
 	if (!ptr_sptr->get())
 		THROW("zero object pointer cannot be dereferenced");
 	CAST_PTR(Base, ptr_object, ptr_sptr->get());
@@ -257,7 +257,7 @@ objectFromHandle(const DataHandle* handle) {
 	void* ptr = handle->data();
 	if (ptr == 0)
 		THROW("zero data pointer cannot be dereferenced");
-	CAST_PTR(boost::shared_ptr<Base>, ptr_sptr, ptr);
+	CAST_PTR(std::shared_ptr<Base>, ptr_sptr, ptr);
 	if (!ptr_sptr->get())
 		THROW("zero object pointer cannot be dereferenced");
 	CAST_PTR(Object, ptr_object, ptr_sptr->get());
@@ -265,12 +265,12 @@ objectFromHandle(const DataHandle* handle) {
 }
 
 template<class Base>
-boost::shared_ptr<Base>&
+std::shared_ptr<Base>&
 objectSptrFromHandle(const DataHandle* handle) {
 	void* ptr = handle->data();
 	if (ptr == 0)
 		THROW("zero data pointer cannot be dereferenced");
-	CAST_PTR(boost::shared_ptr<Base>, ptr_sptr, ptr);
+	CAST_PTR(std::shared_ptr<Base>, ptr_sptr, ptr);
 	if (!ptr_sptr->get())
 		THROW("zero object pointer cannot be dereferenced");
 	return *ptr_sptr;
@@ -284,14 +284,14 @@ objectPtrFromHandle(const DataHandle* handle) {
 	void* ptr = handle->data();
 	if (ptr == 0)
 		return 0;
-	CAST_PTR(boost::shared_ptr<Base>, ptr_sptr, ptr);
+	CAST_PTR(std::shared_ptr<Base>, ptr_sptr, ptr);
 	return ptr_sptr->get();
 }
 
 template<class T>
-boost::shared_ptr<T>
+std::shared_ptr<T>
 sptrDataFromHandle(const DataHandle* handle) {
-	return *(boost::shared_ptr<T>*)handle->data();
+	return *(std::shared_ptr<T>*)handle->data();
 }
 
 #define GRAB 1

--- a/src/xGadgetron/cGadgetron/cgadgetron.cpp
+++ b/src/xGadgetron/cGadgetron/cgadgetron.cpp
@@ -23,7 +23,7 @@ limitations under the License.
 #include <string>
 
 #include <boost/filesystem/operations.hpp>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 #include <ismrmrd/ismrmrd.h>
 #include <ismrmrd/dataset.h>
@@ -44,7 +44,7 @@ return newObjectHandle<aGadget, G>();
 #define NEW_GADGET_CHAIN(C) if (boost::iequals(name, C::class_name())) \
 return newObjectHandle<GadgetChain, C>();
 
-boost::shared_ptr<boost::mutex> Mutex::sptr_mutex_;
+std::shared_ptr<boost::mutex> Mutex::sptr_mutex_;
 
 static void*
 unknownObject(const char* obj, const char* name, const char* file, int line)
@@ -143,7 +143,7 @@ cGT_parameter(void* ptr, const char* obj, const char* name)
 			return cGT_acquisitionsParameter(ptr, name);
 		if (boost::iequals(obj, "gadget_chain")) {
 			GadgetChain& gc = objectFromHandle<GadgetChain>(ptr);
-			boost::shared_ptr<aGadget> sptr = gc.gadget_sptr(name);
+			std::shared_ptr<aGadget> sptr = gc.gadget_sptr(name);
 			if (sptr.get())
 				return sptrObjectHandle(sptr);
 			else {
@@ -184,12 +184,12 @@ cGT_CoilSensitivities(const char* file)
 {
 	try {
 		if (std::strlen(file) > 0) {
-			boost::shared_ptr<CoilSensitivitiesContainer>
+			std::shared_ptr<CoilSensitivitiesContainer>
 				csms(new CoilSensitivitiesAsImages(file));
 			return sptrObjectHandle<CoilSensitivitiesContainer>(csms);
 		}
 		else {
-			boost::shared_ptr<CoilSensitivitiesContainer>
+			std::shared_ptr<CoilSensitivitiesContainer>
 				csms(new CoilSensitivitiesAsImages());
 			return sptrObjectHandle<CoilSensitivitiesContainer>(csms);
 		}
@@ -321,11 +321,11 @@ cGT_AcquisitionModel(const void* ptr_acqs, const void* ptr_imgs)
 	try {
 		CAST_PTR(DataHandle, h_acqs, ptr_acqs);
 		CAST_PTR(DataHandle, h_imgs, ptr_imgs);
-		boost::shared_ptr<AcquisitionsContainer> acqs =
+		std::shared_ptr<AcquisitionsContainer> acqs =
 			objectSptrFromHandle<AcquisitionsContainer>(h_acqs);
-		boost::shared_ptr<ImagesContainer> imgs =
+		std::shared_ptr<ImagesContainer> imgs =
 			objectSptrFromHandle<ImagesContainer>(h_imgs);
-		boost::shared_ptr<AcquisitionModel> am(new AcquisitionModel(acqs, imgs));
+		std::shared_ptr<AcquisitionModel> am(new AcquisitionModel(acqs, imgs));
 		return sptrObjectHandle<AcquisitionModel>(am);
 	}
 	CATCH;
@@ -339,7 +339,7 @@ cGT_setCSMs(void* ptr_am, const void* ptr_csms)
 		CAST_PTR(DataHandle, h_am, ptr_am);
 		CAST_PTR(DataHandle, h_csms, ptr_csms);
 		AcquisitionModel& am = objectFromHandle<AcquisitionModel>(h_am);
-		boost::shared_ptr<CoilSensitivitiesContainer> sptr_csms =
+		std::shared_ptr<CoilSensitivitiesContainer> sptr_csms =
 			objectSptrFromHandle<CoilSensitivitiesContainer>(h_csms);
 		am.setCSMs(sptr_csms);
 		return (void*)new DataHandle;
@@ -356,7 +356,7 @@ cGT_AcquisitionModelForward(void* ptr_am, const void* ptr_imgs)
 		CAST_PTR(DataHandle, h_imgs, ptr_imgs);
 		AcquisitionModel& am = objectFromHandle<AcquisitionModel>(h_am);
 		ImagesContainer& imgs = objectFromHandle<ImagesContainer>(h_imgs);
-		boost::shared_ptr<AcquisitionsContainer> sptr_acqs = am.fwd(imgs);
+		std::shared_ptr<AcquisitionsContainer> sptr_acqs = am.fwd(imgs);
 		return sptrObjectHandle<AcquisitionsContainer>(sptr_acqs);
 	}
 	CATCH;
@@ -372,7 +372,7 @@ cGT_AcquisitionModelBackward(void* ptr_am, const void* ptr_acqs)
 		AcquisitionModel& am = objectFromHandle<AcquisitionModel>(h_am);
 		AcquisitionsContainer& acqs =
 			objectFromHandle<AcquisitionsContainer>(h_acqs);
-		boost::shared_ptr<ImagesContainer> sptr_imgs = am.bwd(acqs);
+		std::shared_ptr<ImagesContainer> sptr_imgs = am.bwd(acqs);
 		return sptrObjectHandle<ImagesContainer>(sptr_imgs);
 	}
 	CATCH;
@@ -415,7 +415,7 @@ cGT_ISMRMRDAcquisitionsFromFile(const char* file)
 	if (!boost::filesystem::exists(file))
 		return fileNotFound(file, __FILE__, __LINE__);
 	try {
-		boost::shared_ptr<AcquisitionsContainer> 
+		std::shared_ptr<AcquisitionsContainer> 
 			acquisitions(new AcquisitionsFile(file));
 		return sptrObjectHandle<AcquisitionsContainer>(acquisitions);
 	}
@@ -427,7 +427,7 @@ void*
 cGT_ISMRMRDAcquisitionsFile(const char* file)
 {
 	try {
-		boost::shared_ptr<AcquisitionsContainer> 
+		std::shared_ptr<AcquisitionsContainer> 
 			acquisitions(new AcquisitionsFile(file, true));
 		return sptrObjectHandle<AcquisitionsContainer>(acquisitions);
 	}
@@ -446,7 +446,7 @@ cGT_processAcquisitions(void* ptr_proc, void* ptr_input)
 		AcquisitionsContainer& input =
 			objectFromHandle<AcquisitionsContainer>(h_input);
 		proc.process(input);
-		boost::shared_ptr<AcquisitionsContainer> sptr_ac = proc.get_output();
+		std::shared_ptr<AcquisitionsContainer> sptr_ac = proc.get_output();
 		return sptrObjectHandle<AcquisitionsContainer>(sptr_ac);
 	}
 	CATCH;
@@ -460,7 +460,7 @@ cGT_acquisitionFromContainer(void* ptr_acqs, unsigned int acq_num)
 		CAST_PTR(DataHandle, h_acqs, ptr_acqs);
 		AcquisitionsContainer& acqs =
 			objectFromHandle<AcquisitionsContainer>(h_acqs);
-		boost::shared_ptr<ISMRMRD::Acquisition>
+		std::shared_ptr<ISMRMRD::Acquisition>
 			sptr_acq(new ISMRMRD::Acquisition);
 		acqs.get_acquisition(acq_num, *sptr_acq);
 		return sptrObjectHandle<ISMRMRD::Acquisition>(sptr_acq);
@@ -476,7 +476,7 @@ cGT_getAcquisitionsDimensions(void* ptr_acqs, size_t ptr_dim)
 		CAST_PTR(DataHandle, h_acqs, ptr_acqs);
 		AcquisitionsContainer& acqs =
 			objectFromHandle<AcquisitionsContainer>(h_acqs);
-		boost::shared_ptr<ISMRMRD::Acquisition>
+		std::shared_ptr<ISMRMRD::Acquisition>
 			sptr_acq(new ISMRMRD::Acquisition);
 		int num_reg_dim = acqs.get_acquisitions_dimensions(ptr_dim);
 		return dataHandle(num_reg_dim);
@@ -492,7 +492,7 @@ cGT_getAcquisitionsFlags(void* ptr_acqs, unsigned int n, size_t ptr_f)
 		CAST_PTR(DataHandle, h_acqs, ptr_acqs);
 		AcquisitionsContainer& acqs =
 			objectFromHandle<AcquisitionsContainer>(h_acqs);
-		boost::shared_ptr<ISMRMRD::Acquisition>
+		std::shared_ptr<ISMRMRD::Acquisition>
 			sptr_acq(new ISMRMRD::Acquisition);
 		acqs.get_acquisitions_flags(n, (int*)ptr_f);
 		return new DataHandle;
@@ -591,7 +591,7 @@ cGT_reconstructImages(void* ptr_recon, void* ptr_input)
 		ImagesReconstructor& recon = objectFromHandle<ImagesReconstructor>(h_recon);
 		AcquisitionsContainer& input = objectFromHandle<AcquisitionsContainer>(h_input);
 		recon.process(input);
-		boost::shared_ptr<ImagesContainer> sptr_img = recon.get_output();
+		std::shared_ptr<ImagesContainer> sptr_img = recon.get_output();
 		return sptrObjectHandle<ImagesContainer>(sptr_img);
 	}
 	CATCH;
@@ -605,7 +605,7 @@ cGT_reconstructedImages(void* ptr_recon)
 	try {
 		CAST_PTR(DataHandle, h_recon, ptr_recon);
 		ImagesReconstructor& recon = objectFromHandle<ImagesReconstructor>(h_recon);
-		boost::shared_ptr<ImagesContainer> sptr_img = recon.get_output();
+		std::shared_ptr<ImagesContainer> sptr_img = recon.get_output();
 		return sptrObjectHandle<ImagesContainer>(sptr_img);
 	}
 	CATCH;
@@ -622,7 +622,7 @@ cGT_processImages(void* ptr_proc, void* ptr_input)
 		ImagesProcessor& proc = objectFromHandle<ImagesProcessor>(h_proc);
 		ImagesContainer& input = objectFromHandle<ImagesContainer>(h_input);
 		proc.process(input);
-		boost::shared_ptr<ImagesContainer> sptr_img = proc.get_output();
+		std::shared_ptr<ImagesContainer> sptr_img = proc.get_output();
 		return sptrObjectHandle<ImagesContainer>(sptr_img);
 	}
 	CATCH;
@@ -636,8 +636,8 @@ cGT_selectImages(void* ptr_input, const char* attr, const char* target)
 	try {
 		CAST_PTR(DataHandle, h_input, ptr_input);
 		ImagesContainer& input = objectFromHandle<ImagesContainer>(h_input);
-		boost::shared_ptr<ImagesContainer> sptr_img = input.clone(attr, target);
-		//boost::shared_ptr<ImagesContainer> sptr_img = input.clone(inc, off);
+		std::shared_ptr<ImagesContainer> sptr_img = input.clone(attr, target);
+		//std::shared_ptr<ImagesContainer> sptr_img = input.clone(inc, off);
 		return sptrObjectHandle<ImagesContainer>(sptr_img);
 	}
 	CATCH;
@@ -651,7 +651,7 @@ cGT_imagesCopy(const void* ptr_imgs)
 		CAST_PTR(DataHandle, h_imgs, ptr_imgs);
 		ImagesContainer& imgs = 
 			(ImagesContainer&)objectFromHandle<ImagesContainer>(h_imgs);
-		boost::shared_ptr<ImagesContainer> clone = imgs.clone();
+		std::shared_ptr<ImagesContainer> clone = imgs.clone();
 		return sptrObjectHandle<ImagesContainer>(clone);
 	}
 	CATCH;
@@ -831,7 +831,7 @@ float br, float bi, const void* ptr_y
 			objectFromHandle<aDataContainer<complex_float_t> >(h_x);
 		aDataContainer<complex_float_t>& y = 
 			objectFromHandle<aDataContainer<complex_float_t> >(h_y);
-		boost::shared_ptr<aDataContainer<complex_float_t> > sptr_z = 
+		std::shared_ptr<aDataContainer<complex_float_t> > sptr_z = 
 			x.new_data_container();
 		complex_float_t a(ar, ai);
 		complex_float_t b(br, bi);
@@ -864,7 +864,7 @@ cGT_addReader(void* ptr_gc, const char* id, const void* ptr_r)
 		CAST_PTR(DataHandle, h_gc, ptr_gc);
 		CAST_PTR(DataHandle, h_r, ptr_r);
 		GadgetChain& gc = objectFromHandle<GadgetChain>(h_gc);
-		boost::shared_ptr<aGadget>& g = objectSptrFromHandle<aGadget>(h_r);
+		std::shared_ptr<aGadget>& g = objectSptrFromHandle<aGadget>(h_r);
 		gc.add_reader(id, g);
 	}
 	CATCH;
@@ -880,7 +880,7 @@ cGT_addWriter(void* ptr_gc, const char* id, const void* ptr_w)
 		CAST_PTR(DataHandle, h_gc, ptr_gc);
 		CAST_PTR(DataHandle, h_w, ptr_w);
 		GadgetChain& gc = objectFromHandle<GadgetChain>(h_gc);
-		boost::shared_ptr<aGadget>& g = objectSptrFromHandle<aGadget>(h_w);
+		std::shared_ptr<aGadget>& g = objectSptrFromHandle<aGadget>(h_w);
 		gc.add_writer(id, g);
 	}
 	CATCH;
@@ -896,7 +896,7 @@ cGT_addGadget(void* ptr_gc, const char* id, const void* ptr_g)
 		CAST_PTR(DataHandle, h_gc, ptr_gc);
 		CAST_PTR(DataHandle, h_g, ptr_g);
 		GadgetChain& gc = objectFromHandle<GadgetChain>(h_gc);
-		boost::shared_ptr<aGadget>& g = objectSptrFromHandle<aGadget>(h_g);
+		std::shared_ptr<aGadget>& g = objectSptrFromHandle<aGadget>(h_g);
 		gc.add_gadget(id, g);
 	}
 	CATCH;
@@ -988,10 +988,10 @@ cGT_registerImagesReceiver(void* ptr_con, void* ptr_img)
 		CAST_PTR(DataHandle, h_img, ptr_img);
 		GTConnector& conn = objectFromHandle<GTConnector>(h_con);
 		GadgetronClientConnector& con = conn();
-		boost::shared_ptr<ImagesContainer> sptr_images =
+		std::shared_ptr<ImagesContainer> sptr_images =
 			objectSptrFromHandle<ImagesContainer>(h_img);
 		con.register_reader(GADGET_MESSAGE_ISMRMRD_IMAGE,
-			boost::shared_ptr<GadgetronClientMessageReader>
+			std::shared_ptr<GadgetronClientMessageReader>
 			(new GadgetronClientImageMessageCollector(sptr_images)));
 	}
 	CATCH;

--- a/src/xGadgetron/cGadgetron/chain_lib.h
+++ b/src/xGadgetron/cGadgetron/chain_lib.h
@@ -28,7 +28,7 @@ public:
 	RemoveOversamplingProcessor()
 	{
 		//class_ = "RemoveOversamplingProcessor";
-		boost::shared_ptr<aGadget> sptr_g(new RemoveROOversamplingGadget);
+		std::shared_ptr<aGadget> sptr_g(new RemoveROOversamplingGadget);
 		add_gadget("gadget", sptr_g);
 	}
 	static const char* class_name()
@@ -42,7 +42,7 @@ public:
 	SimpleReconstructionProcessor()
 	{
 		//class_ = "SimpleReconstructionProcessor";
-		boost::shared_ptr<aGadget> sptr_g(new SimpleReconGadgetSet);
+		std::shared_ptr<aGadget> sptr_g(new SimpleReconGadgetSet);
 		add_gadget("gadget", sptr_g);
 	}
 	static const char* class_name()
@@ -56,15 +56,15 @@ public:
 	SimpleGRAPPAReconstructionProcessor()
 	{
 		//class_ = "SimpleGRAPPAReconstructionProcessor";
-		boost::shared_ptr<aGadget> sptr_g1(new AcquisitionAccumulateTriggerGadget);
-		boost::shared_ptr<aGadget> sptr_g2(new BucketToBufferGadget);
-		boost::shared_ptr<aGadget> sptr_g3
+		std::shared_ptr<aGadget> sptr_g1(new AcquisitionAccumulateTriggerGadget);
+		std::shared_ptr<aGadget> sptr_g2(new BucketToBufferGadget);
+		std::shared_ptr<aGadget> sptr_g3
 			(new GenericReconCartesianReferencePrepGadget);
-		boost::shared_ptr<aGadget> sptr_g4(new GenericReconCartesianGrappaGadget);
-		boost::shared_ptr<aGadget> sptr_g5
+		std::shared_ptr<aGadget> sptr_g4(new GenericReconCartesianGrappaGadget);
+		std::shared_ptr<aGadget> sptr_g5
 			(new GenericReconFieldOfViewAdjustmentGadget);
-		boost::shared_ptr<aGadget> sptr_g6(new GenericReconImageArrayScalingGadget);
-		boost::shared_ptr<aGadget> sptr_g7(new ImageArraySplitGadget);
+		std::shared_ptr<aGadget> sptr_g6(new GenericReconImageArrayScalingGadget);
+		std::shared_ptr<aGadget> sptr_g7(new ImageArraySplitGadget);
 		add_gadget("gadget1", sptr_g1);
 		add_gadget("gadget2", sptr_g2);
 		add_gadget("gadget3", sptr_g3);
@@ -84,7 +84,7 @@ public:
 	ExtractRealImagesProcessor()
 	{
 		//class_ = "ExtractRealImagesProcessor";
-		boost::shared_ptr<aGadget> sptr_g(new ExtractGadget);
+		std::shared_ptr<aGadget> sptr_g(new ExtractGadget);
 		add_gadget("gadget", sptr_g);
 	}
 	static const char* class_name()

--- a/src/xGadgetron/cGadgetron/gadgetron_client.h
+++ b/src/xGadgetron/cGadgetron/gadgetron_client.h
@@ -22,7 +22,7 @@ limitations under the License.
 #define GADGETRON_CLIENT
 
 #include <boost/asio.hpp>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 #include <boost/thread/mutex.hpp>
 #include <boost/thread/thread.hpp>
 
@@ -97,20 +97,20 @@ class GadgetronClientAcquisitionMessageCollector :
 	public GadgetronClientMessageReader {
 public:
 	GadgetronClientAcquisitionMessageCollector
-		(boost::shared_ptr<AcquisitionsContainer> ptr_acqs) : ptr_acqs_(ptr_acqs) {}
+		(std::shared_ptr<AcquisitionsContainer> ptr_acqs) : ptr_acqs_(ptr_acqs) {}
 	virtual ~GadgetronClientAcquisitionMessageCollector() {}
 
 	virtual void read(tcp::socket* stream);
 
 private:
-	boost::shared_ptr<AcquisitionsContainer> ptr_acqs_;
+	std::shared_ptr<AcquisitionsContainer> ptr_acqs_;
 };
 
 class GadgetronClientImageMessageCollector : 
 	public GadgetronClientMessageReader {
 public:
 	GadgetronClientImageMessageCollector
-		(boost::shared_ptr<ImagesContainer> ptr_images) : ptr_images_(ptr_images) {}
+		(std::shared_ptr<ImagesContainer> ptr_images) : ptr_images_(ptr_images) {}
 	virtual ~GadgetronClientImageMessageCollector() {}
 
 	template <typename T>
@@ -143,7 +143,7 @@ public:
 	virtual void read(tcp::socket* stream);
 
 private:
-	boost::shared_ptr<ImagesContainer> ptr_images_;
+	std::shared_ptr<ImagesContainer> ptr_images_;
 };
 
 class GadgetronClientConnector {
@@ -225,14 +225,14 @@ public:
 	}
 
 	void register_reader
-		(unsigned short slot, boost::shared_ptr<GadgetronClientMessageReader> r) 
+		(unsigned short slot, std::shared_ptr<GadgetronClientMessageReader> r) 
 	{
 		readers_[slot] = r;
 	}
 
 protected:
 	typedef 
-		std::map<unsigned short, boost::shared_ptr<GadgetronClientMessageReader> > 
+		std::map<unsigned short, std::shared_ptr<GadgetronClientMessageReader> > 
 		maptype;
 
 	GadgetronClientMessageReader* find_reader(unsigned short r);

--- a/src/xGadgetron/cGadgetron/gadgetron_data_containers.cpp
+++ b/src/xGadgetron/cGadgetron/gadgetron_data_containers.cpp
@@ -29,10 +29,10 @@ limitations under the License.
 
 #include "gadgetron_data_containers.h"
 
-boost::shared_ptr<AcquisitionsContainer> 
+std::shared_ptr<AcquisitionsContainer> 
 AcquisitionsContainer::acqs_templ_;
 
-//boost::shared_ptr<AcquisitionsContainer> 
+//std::shared_ptr<AcquisitionsContainer> 
 //AcquisitionsContainerTemplate::acqs_storage_template_;
 
 void 
@@ -445,7 +445,7 @@ AcquisitionsFile::AcquisitionsFile
 	filename_ = filename;
 	Mutex mtx;
 	mtx.lock();
-	dataset_ = boost::shared_ptr<ISMRMRD::Dataset>
+	dataset_ = std::shared_ptr<ISMRMRD::Dataset>
 		(new ISMRMRD::Dataset(filename.c_str(), "/dataset", create_file));
 	if (!create_file) {
 		dataset_->readHeader(acqs_info_);
@@ -463,7 +463,7 @@ AcquisitionsFile::AcquisitionsFile(AcquisitionsInfo info)
 	filename_ = xGadgetronUtilities::scratch_file_name();
 	Mutex mtx;
 	mtx.lock();
-	dataset_ = boost::shared_ptr<ISMRMRD::Dataset>
+	dataset_ = std::shared_ptr<ISMRMRD::Dataset>
 		(new ISMRMRD::Dataset(filename_.c_str(), "/dataset", true));
 	acqs_info_ = info;
 	dataset_->writeHeader(acqs_info_);
@@ -562,7 +562,7 @@ int
 AcquisitionsFile::set_acquisition_data
 (int na, int nc, int ns, const float* re, const float* im)
 {
-	boost::shared_ptr<AcquisitionsContainer> sptr_ac =
+	std::shared_ptr<AcquisitionsContainer> sptr_ac =
 		this->new_acquisitions_container();
 	AcquisitionsFile* ptr_ac = (AcquisitionsFile*)sptr_ac.get();
 	ptr_ac->set_acquisitions_info(acqs_info_);
@@ -659,12 +659,12 @@ ImagesContainer::norm()
 ImagesVector::ImagesVector(const ImagesVector& list, const char* attr, const char* target)
 {
 #ifdef _MSC_VER
-	std::vector<boost::shared_ptr<ImageWrap> >::const_iterator i;
+	std::vector<std::shared_ptr<ImageWrap> >::const_iterator i;
 #else
-	typename std::vector<boost::shared_ptr<ImageWrap> >::const_iterator i;
+	typename std::vector<std::shared_ptr<ImageWrap> >::const_iterator i;
 #endif
 	for (i = list.images_.begin(); i != list.images_.end(); i++) {
-		const boost::shared_ptr<ImageWrap>& sptr_iw = *i;
+		const std::shared_ptr<ImageWrap>& sptr_iw = *i;
 		std::string atts = sptr_iw->attributes();
 		ISMRMRD::MetaContainer mc;
 		ISMRMRD::deserialize(atts.c_str(), mc);
@@ -679,16 +679,16 @@ ImagesVector::ImagesVector(const ImagesVector& list, unsigned int inc, unsigned 
 	int n = 0;
 	unsigned int j = 0;
 #ifdef _MSC_VER
-	std::vector<boost::shared_ptr<ImageWrap> >::const_iterator i;
+	std::vector<std::shared_ptr<ImageWrap> >::const_iterator i;
 #else
-	typename std::vector<boost::shared_ptr<ImageWrap> >::const_iterator i;
+	typename std::vector<std::shared_ptr<ImageWrap> >::const_iterator i;
 #endif
 	for (i = list.images_.begin(); i != list.images_.end() && j < off; i++, j++);
 
 	for (; i != list.images_.end(); i++, j++) {
 		if ((j - off) % inc)
 			continue;
-		const boost::shared_ptr<ImageWrap>& sptr_iw = *i;
+		const std::shared_ptr<ImageWrap>& sptr_iw = *i;
 		append(*sptr_iw);
 		n++;
 	}
@@ -705,12 +705,12 @@ ImagesVector::write(std::string filename, std::string groupname)
 	ISMRMRD::Dataset dataset(filename.c_str(), groupname.c_str());
 	mtx.unlock();
 #ifdef _MSC_VER
-	std::vector<boost::shared_ptr<ImageWrap> >::iterator i;
+	std::vector<std::shared_ptr<ImageWrap> >::iterator i;
 #else
-	typename std::vector<boost::shared_ptr<ImageWrap> >::iterator i;
+	typename std::vector<std::shared_ptr<ImageWrap> >::iterator i;
 #endif
 	for (i = images_.begin(); i != images_.end(); i++) {
-		boost::shared_ptr<ImageWrap>& sptr_iw = *i;
+		std::shared_ptr<ImageWrap>& sptr_iw = *i;
 		ImageWrap& iw = *sptr_iw;
 		iw.write(dataset);
 	}
@@ -720,13 +720,13 @@ void
 ImagesVector::get_images_data_as_float_array(float* data) const
 {
 #ifdef _MSC_VER
-	std::vector<boost::shared_ptr<ImageWrap> >::const_iterator i;
+	std::vector<std::shared_ptr<ImageWrap> >::const_iterator i;
 #else
-	typename std::vector<boost::shared_ptr<ImageWrap> >::const_iterator i;
+	typename std::vector<std::shared_ptr<ImageWrap> >::const_iterator i;
 #endif
 	int dim[4];
 	for (i = images_.begin(); i != images_.end(); i++) {
-		const boost::shared_ptr<ImageWrap>& sptr_iw = *i;
+		const std::shared_ptr<ImageWrap>& sptr_iw = *i;
 		ImageWrap& iw = *sptr_iw;
 		iw.get_data(data);
 		iw.get_dim(dim);
@@ -742,13 +742,13 @@ void
 ImagesVector::get_images_data_as_complex_array(float* re, float* im) const
 {
 #ifdef _MSC_VER
-	std::vector<boost::shared_ptr<ImageWrap> >::const_iterator i;
+	std::vector<std::shared_ptr<ImageWrap> >::const_iterator i;
 #else
-	typename std::vector<boost::shared_ptr<ImageWrap> >::const_iterator i;
+	typename std::vector<std::shared_ptr<ImageWrap> >::const_iterator i;
 #endif
 	int dim[4];
 	for (i = images_.begin(); i != images_.end(); i++) {
-		const boost::shared_ptr<ImageWrap>& sptr_iw = *i;
+		const std::shared_ptr<ImageWrap>& sptr_iw = *i;
 		ImageWrap& iw = *sptr_iw;
 		iw.get_dim(dim);
 		size_t size = dim[0];
@@ -772,13 +772,13 @@ void
 ImagesVector::set_complex_images_data(const float* re, const float* im)
 {
 #ifdef _MSC_VER
-	std::vector<boost::shared_ptr<ImageWrap> >::iterator i;
+	std::vector<std::shared_ptr<ImageWrap> >::iterator i;
 #else
-	typename std::vector<boost::shared_ptr<ImageWrap> >::iterator i;
+	typename std::vector<std::shared_ptr<ImageWrap> >::iterator i;
 #endif
 	int dim[4];
 	for (i = images_.begin(); i != images_.end(); i++) {
-		boost::shared_ptr<ImageWrap>& sptr_iw = *i;
+		std::shared_ptr<ImageWrap>& sptr_iw = *i;
 		ImageWrap& iw = *sptr_iw;
 		size_t n = iw.get_dim(dim);
 		iw.set_cmplx_data(re, im);
@@ -890,7 +890,7 @@ CoilImagesContainer::compute(AcquisitionsContainer& ac)
 
 		ifft2c(ci);
 
-		boost::shared_ptr<CoilData>
+		std::shared_ptr<CoilData>
 			sptr_ci(new CoilDataAsCFImage(readout, ny, 1, nc));
 		CFImage& coil_im = (*(CoilDataAsCFImage*)sptr_ci.get()).image();
 		memcpy(coil_im.getDataPtr(), ci.getDataPtr(), ci.getDataSize());
@@ -937,7 +937,7 @@ CoilSensitivitiesContainer::compute(CoilImagesContainer& cis)
 		cis(nmap - 1).get_data(cm.getDataPtr());
 		//CoilData* ptr_img = new CoilDataType(nx, ny, 1, nc);
 		CoilData* ptr_img = new CoilDataAsCFImage(nx, ny, 1, nc);
-		boost::shared_ptr<CoilData> sptr_img(ptr_img);
+		std::shared_ptr<CoilData> sptr_img(ptr_img);
 		compute_csm_(cm, img, csm);
 		ptr_img->set_data(csm.getDataPtr());
 		append(sptr_img);
@@ -1162,7 +1162,7 @@ CoilSensitivitiesAsImages::CoilSensitivitiesAsImages(const char* file)
 	int nm = csm_file.getNumberOfImages("csm");
 	mtx.unlock();
 	for (int i = 0; i < nm; i++) {
-		boost::shared_ptr<CoilData> sptr_img(new CoilDataAsCFImage);
+		std::shared_ptr<CoilData> sptr_img(new CoilDataAsCFImage);
 		mtx.lock();
 		CFImage& csm = (*(CoilDataAsCFImage*)sptr_img.get()).image();
 		csm_file.readImage("csm", i, csm);

--- a/src/xGadgetron/cGadgetron/gadgetron_data_containers.h
+++ b/src/xGadgetron/cGadgetron/gadgetron_data_containers.h
@@ -69,7 +69,7 @@ namespace Multisort {
 
 #include <boost/thread/thread.hpp>
 #include <boost/thread/mutex.hpp>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/algorithm/string/replace.hpp>
 
@@ -195,7 +195,7 @@ public:
 	{
 		return *sptr_mutex_.get();
 	}
-	boost::shared_ptr<boost::mutex> sptr() 
+	std::shared_ptr<boost::mutex> sptr() 
 	{
 		return sptr_mutex_;
 	}
@@ -208,12 +208,12 @@ public:
 		sptr_mutex_->unlock();
 	}
 private:
-	static boost::shared_ptr<boost::mutex> sptr_mutex_;
+	static std::shared_ptr<boost::mutex> sptr_mutex_;
 	static void init_() 
 	{
 		static bool initialized = false;
 		if (!initialized) {
-			sptr_mutex_ = boost::shared_ptr<boost::mutex>(new boost::mutex);
+			sptr_mutex_ = std::shared_ptr<boost::mutex>(new boost::mutex);
 			initialized = true;
 		}
 	}
@@ -469,7 +469,7 @@ template <typename T>
 class aDataContainer {
 public:
 	virtual ~aDataContainer() {}
-	virtual boost::shared_ptr<aDataContainer<T> > new_data_container() = 0;
+	virtual std::shared_ptr<aDataContainer<T> > new_data_container() = 0;
 	virtual unsigned int items() = 0;
 	virtual float norm() = 0;
 	virtual T dot(aDataContainer<T>& dc) = 0;
@@ -517,7 +517,7 @@ public:
 	virtual void append_acquisition(ISMRMRD::Acquisition& acq) = 0;
 	virtual void copy_acquisitions_info(const AcquisitionsContainer& ac) = 0;
 	virtual 
-		boost::shared_ptr<AcquisitionsContainer> new_acquisitions_container() = 0;
+		std::shared_ptr<AcquisitionsContainer> new_acquisitions_container() = 0;
 	virtual AcquisitionsContainer* same_acquisitions_container(AcquisitionsInfo info) = 0;
 	virtual int set_acquisition_data
 		(int na, int nc, int ns, const float* re, const float* im) = 0;
@@ -552,7 +552,7 @@ protected:
 	bool ordered_;
 	int* index_;
 	AcquisitionsInfo acqs_info_;
-	static boost::shared_ptr<AcquisitionsContainer> acqs_templ_;
+	static std::shared_ptr<AcquisitionsContainer> acqs_templ_;
 };
 
 class AcquisitionsFile : public AcquisitionsContainer {
@@ -592,24 +592,24 @@ public:
 	{
 		return (AcquisitionsContainer*) new AcquisitionsFile(info);
 	}
-	virtual boost::shared_ptr<aDataContainer<complex_float_t> > 
+	virtual std::shared_ptr<aDataContainer<complex_float_t> > 
 		new_data_container()
 	{
 		init();
-		return boost::shared_ptr<aDataContainer<complex_float_t> >
+		return std::shared_ptr<aDataContainer<complex_float_t> >
 			(acqs_templ_->same_acquisitions_container(acqs_info_));
 	}
-	virtual boost::shared_ptr<AcquisitionsContainer> new_acquisitions_container()
+	virtual std::shared_ptr<AcquisitionsContainer> new_acquisitions_container()
 	{
 		init();
-		return boost::shared_ptr<AcquisitionsContainer>
+		return std::shared_ptr<AcquisitionsContainer>
 			(acqs_templ_->same_acquisitions_container(acqs_info_));
 	}
 
 private:
 	bool own_file_;
 	std::string filename_;
-	boost::shared_ptr<ISMRMRD::Dataset> dataset_;
+	std::shared_ptr<ISMRMRD::Dataset> dataset_;
 };
 
 class AcquisitionsVector : public AcquisitionsContainer {
@@ -628,7 +628,7 @@ public:
 	virtual unsigned int items() { return (unsigned int)acqs_.size(); }
 	virtual void append_acquisition(ISMRMRD::Acquisition& acq)
 	{
-		acqs_.push_back(boost::shared_ptr<ISMRMRD::Acquisition>
+		acqs_.push_back(std::shared_ptr<ISMRMRD::Acquisition>
 			(new ISMRMRD::Acquisition(acq)));
 	}
 	virtual void get_acquisition(unsigned int num, ISMRMRD::Acquisition& acq)
@@ -646,21 +646,21 @@ public:
 	{
 		return new AcquisitionsVector(info);
 	}
-	virtual boost::shared_ptr<aDataContainer<complex_float_t> > new_data_container()
+	virtual std::shared_ptr<aDataContainer<complex_float_t> > new_data_container()
 	{
 		AcquisitionsFile::init();
-		return boost::shared_ptr<aDataContainer<complex_float_t> >
+		return std::shared_ptr<aDataContainer<complex_float_t> >
 			(acqs_templ_->same_acquisitions_container(acqs_info_));
 	}
-	virtual boost::shared_ptr<AcquisitionsContainer> new_acquisitions_container()
+	virtual std::shared_ptr<AcquisitionsContainer> new_acquisitions_container()
 	{
 		AcquisitionsFile::init();
-		return boost::shared_ptr<AcquisitionsContainer>
+		return std::shared_ptr<AcquisitionsContainer>
 			(acqs_templ_->same_acquisitions_container(acqs_info_));
 	}
 
 private:
-	std::vector<boost::shared_ptr<ISMRMRD::Acquisition> > acqs_;
+	std::vector<std::shared_ptr<ISMRMRD::Acquisition> > acqs_;
 };
 
 class ImagesContainer : public aDataContainer<complex_float_t> {
@@ -668,8 +668,8 @@ public:
 	virtual unsigned int number() = 0;
 	virtual int types() = 0;
 	virtual void count(int i) = 0;
-	virtual boost::shared_ptr<ImageWrap> sptr_image_wrap(unsigned int im_num) = 0;
-	virtual boost::shared_ptr<const ImageWrap> sptr_image_wrap
+	virtual std::shared_ptr<ImageWrap> sptr_image_wrap(unsigned int im_num) = 0;
+	virtual std::shared_ptr<const ImageWrap> sptr_image_wrap
 		(unsigned int im_num) const = 0;
 	virtual ImageWrap& image_wrap(unsigned int im_num) = 0;
 	virtual const ImageWrap& image_wrap(unsigned int im_num) const = 0;
@@ -681,10 +681,10 @@ public:
 		(float* re, float* im) const = 0;
 	virtual void set_complex_images_data(const float* re, const float* im) = 0;
 	virtual void write(std::string filename, std::string groupname) = 0;
-	virtual boost::shared_ptr<ImagesContainer> new_images_container() = 0;
-	virtual boost::shared_ptr<ImagesContainer>
+	virtual std::shared_ptr<ImagesContainer> new_images_container() = 0;
+	virtual std::shared_ptr<ImagesContainer>
 		clone(unsigned int inc = 1, unsigned int off = 0) = 0;
-	virtual boost::shared_ptr<ImagesContainer>
+	virtual std::shared_ptr<ImagesContainer>
 		clone(const char* attr, const char* target) = 0;
 	virtual int image_data_type(unsigned int im_num) const
 	{
@@ -728,30 +728,30 @@ public:
 	}
 	virtual void append(int image_data_type, void* ptr_image)
 	{
-		images_.push_back(boost::shared_ptr<ImageWrap>
+		images_.push_back(std::shared_ptr<ImageWrap>
 			(new ImageWrap(image_data_type, ptr_image)));
 	}
 	virtual void append(const ImageWrap& iw)
 	{
-		images_.push_back(boost::shared_ptr<ImageWrap>(new ImageWrap(iw)));
+		images_.push_back(std::shared_ptr<ImageWrap>(new ImageWrap(iw)));
 	}
-	virtual boost::shared_ptr<ImageWrap> sptr_image_wrap(unsigned int im_num)
+	virtual std::shared_ptr<ImageWrap> sptr_image_wrap(unsigned int im_num)
 	{
 		return images_[im_num];
 	}
-	virtual boost::shared_ptr<const ImageWrap> sptr_image_wrap
+	virtual std::shared_ptr<const ImageWrap> sptr_image_wrap
 	(unsigned int im_num) const
 	{
 		return images_[im_num];
 	}
 	virtual ImageWrap& image_wrap(unsigned int im_num)
 	{
-		boost::shared_ptr<ImageWrap> sptr_iw = sptr_image_wrap(im_num);
+		std::shared_ptr<ImageWrap> sptr_iw = sptr_image_wrap(im_num);
 		return *sptr_iw;
 	}
 	virtual const ImageWrap& image_wrap(unsigned int im_num) const
 	{
-		const boost::shared_ptr<const ImageWrap>& sptr_iw = sptr_image_wrap(im_num);
+		const std::shared_ptr<const ImageWrap>& sptr_iw = sptr_image_wrap(im_num);
 		return *sptr_iw;
 	}
 	virtual void write(std::string filename, std::string groupname);
@@ -770,28 +770,28 @@ public:
 	virtual void get_images_data_as_float_array(float* data) const;
 	virtual void get_images_data_as_complex_array(float* re, float* im) const;
 	virtual void set_complex_images_data(const float* re, const float* im);
-	virtual boost::shared_ptr<aDataContainer<complex_float_t> > new_data_container()
+	virtual std::shared_ptr<aDataContainer<complex_float_t> > new_data_container()
 	{
-		return boost::shared_ptr<aDataContainer<complex_float_t> >
+		return std::shared_ptr<aDataContainer<complex_float_t> >
 			((aDataContainer<complex_float_t>*)new ImagesVector());
 	}
-	virtual boost::shared_ptr<ImagesContainer> new_images_container()
+	virtual std::shared_ptr<ImagesContainer> new_images_container()
 	{
-		return boost::shared_ptr<ImagesContainer>((ImagesContainer*)new ImagesVector());
+		return std::shared_ptr<ImagesContainer>((ImagesContainer*)new ImagesVector());
 	}
-	virtual boost::shared_ptr<ImagesContainer>
+	virtual std::shared_ptr<ImagesContainer>
 		clone(const char* attr, const char* target)
 	{
-		return boost::shared_ptr<ImagesContainer>(new ImagesVector(*this, attr, target));
+		return std::shared_ptr<ImagesContainer>(new ImagesVector(*this, attr, target));
 	}
-	virtual boost::shared_ptr<ImagesContainer>
+	virtual std::shared_ptr<ImagesContainer>
 		clone(unsigned int inc = 1, unsigned int off = 0)
 	{
-		return boost::shared_ptr<ImagesContainer>(new ImagesVector(*this, inc, off));
+		return std::shared_ptr<ImagesContainer>(new ImagesVector(*this, inc, off));
 	}
 
 private:
-	std::vector<boost::shared_ptr<ImageWrap> > images_;
+	std::vector<std::shared_ptr<ImageWrap> > images_;
 	int nimages_;
 };
 
@@ -894,7 +894,7 @@ public:
 		CoilData& ci = (CoilData&)(*this)(slice);
 		ci.get_data_abs(v);
 	}
-	virtual void append(boost::shared_ptr<CoilData> sptr_csm) = 0;
+	virtual void append(std::shared_ptr<CoilData> sptr_csm) = 0;
 	virtual CoilData& operator()(int slice) = 0;
 	//virtual const CoilData& operator()(int slice) const = 0;
 };
@@ -908,12 +908,12 @@ public:
 	CoilData& data(int slice) {
 		return *coil_data_[slice];
 	}
-	virtual void append(boost::shared_ptr<CoilData> sptr_cd)
+	virtual void append(std::shared_ptr<CoilData> sptr_cd)
 	{
 		coil_data_.push_back(sptr_cd);
 	}
 private:
-	std::vector< boost::shared_ptr<CoilData> > coil_data_;
+	std::vector< std::shared_ptr<CoilData> > coil_data_;
 };
 
 class CoilImagesContainer : public CoilDataContainer {
@@ -930,9 +930,9 @@ protected:
 
 class CoilImagesVector : public CoilImagesContainer, public CoilDataVector {
 public:
-	virtual boost::shared_ptr<aDataContainer<complex_float_t> > new_data_container()
+	virtual std::shared_ptr<aDataContainer<complex_float_t> > new_data_container()
 	{
-		return boost::shared_ptr<aDataContainer<complex_float_t> >
+		return std::shared_ptr<aDataContainer<complex_float_t> >
 			((aDataContainer<complex_float_t>*)new CoilImagesVector());
 	}
 	virtual unsigned int items()
@@ -943,7 +943,7 @@ public:
 	{
 		return data(slice);
 	}
-	virtual void append(boost::shared_ptr<CoilData> sptr_cd)
+	virtual void append(std::shared_ptr<CoilData> sptr_cd)
 	{
 		CoilDataVector::append(sptr_cd);
 	}
@@ -975,7 +975,7 @@ public:
 	{
 		//CoilData* ptr_img = new CoilDataType(nx, ny, nz, nc);
 		CoilData* ptr_img = new CoilDataAsCFImage(nx, ny, nz, nc);
-		boost::shared_ptr<CoilData> sptr_img(ptr_img);
+		std::shared_ptr<CoilData> sptr_img(ptr_img);
 		ptr_img->set_data(re, im);
 		append(sptr_img);
 	}
@@ -1011,9 +1011,9 @@ public:
 	}
 	CoilSensitivitiesAsImages(const char* file);
 
-	virtual boost::shared_ptr<aDataContainer<complex_float_t> > new_data_container()
+	virtual std::shared_ptr<aDataContainer<complex_float_t> > new_data_container()
 	{
-		return boost::shared_ptr<aDataContainer<complex_float_t> >
+		return std::shared_ptr<aDataContainer<complex_float_t> >
 			((aDataContainer<complex_float_t>*)new CoilSensitivitiesAsImages());
 	}
 
@@ -1025,7 +1025,7 @@ public:
 	{
 		return data(slice);
 	}
-	virtual void append(boost::shared_ptr<CoilData> sptr_cd)
+	virtual void append(std::shared_ptr<CoilData> sptr_cd)
 	{
 		CoilDataVector::append(sptr_cd);
 	}

--- a/src/xGadgetron/cGadgetron/gadgetron_x.cpp
+++ b/src/xGadgetron/cGadgetron/gadgetron_x.cpp
@@ -45,19 +45,19 @@ connection_failed(int nt)
 
 }
 
-boost::shared_ptr<aGadget> 
+std::shared_ptr<aGadget> 
 GadgetChain::gadget_sptr(std::string id)
 {
 #ifdef _MSC_VER
-	std::list<boost::shared_ptr<GadgetHandle> >::iterator gh;
+	std::list<std::shared_ptr<GadgetHandle> >::iterator gh;
 #else
-	typename std::list<boost::shared_ptr<GadgetHandle> >::iterator gh;
+	typename std::list<std::shared_ptr<GadgetHandle> >::iterator gh;
 #endif
 	for (gh = gadgets_.begin(); gh != gadgets_.end(); gh++) {
 		if (boost::iequals(gh->get()->id(), id))
 			return gh->get()->gadget_sptr();
 	}
-	return boost::shared_ptr<aGadget>();
+	return std::shared_ptr<aGadget>();
 }
 
 std::string 
@@ -70,9 +70,9 @@ GadgetChain::xml() const
 	xml_script += "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n\n";
 
 #ifdef _MSC_VER
-	std::list<boost::shared_ptr<GadgetHandle> >::const_iterator gh;
+	std::list<std::shared_ptr<GadgetHandle> >::const_iterator gh;
 #else
-	typename std::list<boost::shared_ptr<GadgetHandle> >::const_iterator gh;
+	typename std::list<std::shared_ptr<GadgetHandle> >::const_iterator gh;
 #endif
 	for (gh = readers_.begin(); gh != readers_.end(); gh++)
 		xml_script += gh->get()->gadget().xml() + '\n';
@@ -99,7 +99,7 @@ AcquisitionsProcessor::process(AcquisitionsContainer& acquisitions)
 	//sptr_acqs_->copy_acquisitions_info(acquisitions);
 	sptr_acqs_ = acquisitions.new_acquisitions_container();
 	conn().register_reader(GADGET_MESSAGE_ISMRMRD_ACQUISITION,
-		boost::shared_ptr<GadgetronClientMessageReader>
+		std::shared_ptr<GadgetronClientMessageReader>
 		(new GadgetronClientAcquisitionMessageCollector(sptr_acqs_)));
 
 	for (int nt = 0; nt < N_TRIALS; nt++) {
@@ -145,7 +145,7 @@ ImagesReconstructor::process(AcquisitionsContainer& acquisitions)
 	//sptr_images_.reset(new ImagesList);
 	sptr_images_.reset(new ImagesVector);
 	conn().register_reader(GADGET_MESSAGE_ISMRMRD_IMAGE,
-		boost::shared_ptr<GadgetronClientMessageReader>
+		std::shared_ptr<GadgetronClientMessageReader>
 		(new GadgetronClientImageMessageCollector(sptr_images_)));
 
 	for (int nt = 0; nt < N_TRIALS; nt++) {
@@ -188,7 +188,7 @@ ImagesProcessor::process(ImagesContainer& images)
 
 	sptr_images_ = images.new_images_container();
 	conn().register_reader(GADGET_MESSAGE_ISMRMRD_IMAGE,
-		boost::shared_ptr<GadgetronClientMessageReader>
+		std::shared_ptr<GadgetronClientMessageReader>
 		(new GadgetronClientImageMessageCollector(sptr_images_)));
 
 	for (int nt = 0; nt < N_TRIALS; nt++) {

--- a/src/xGadgetron/cGadgetron/gadgetron_x.h
+++ b/src/xGadgetron/cGadgetron/gadgetron_x.h
@@ -34,7 +34,7 @@ limitations under the License.
 #include <string>
 
 #include <boost/thread/mutex.hpp>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 #include <ismrmrd/ismrmrd.h>
 #include <ismrmrd/dataset.h>
@@ -59,19 +59,19 @@ class GTConnector {
 public:
 	GTConnector() 
 	{
-		sptr_con_ = boost::shared_ptr<GadgetronClientConnector>
+		sptr_con_ = std::shared_ptr<GadgetronClientConnector>
 			(new GadgetronClientConnector);
 	}
 	GadgetronClientConnector& operator()() 
 	{
 		return *sptr_con_.get();
 	}
-	boost::shared_ptr<GadgetronClientConnector> sptr() 
+	std::shared_ptr<GadgetronClientConnector> sptr() 
 	{
 		return sptr_con_;
 	}
 private:
-	boost::shared_ptr<GadgetronClientConnector> sptr_con_;
+	std::shared_ptr<GadgetronClientConnector> sptr_con_;
 };
 
 /*!
@@ -82,7 +82,7 @@ private:
 
 class GadgetHandle {
 public:
-	GadgetHandle(std::string id, boost::shared_ptr<aGadget> sptr_g) : 
+	GadgetHandle(std::string id, std::shared_ptr<aGadget> sptr_g) : 
 		id_(id), sptr_g_(sptr_g) {}
 	std::string id() const 
 	{
@@ -96,13 +96,13 @@ public:
 	{
 		return *sptr_g_.get();
 	}
-	boost::shared_ptr<aGadget> gadget_sptr()
+	std::shared_ptr<aGadget> gadget_sptr()
 	{
 		return sptr_g_;
 	}
 private:
 	std::string id_;
-	boost::shared_ptr<aGadget> sptr_g_;
+	std::shared_ptr<aGadget> sptr_g_;
 };
 
 /*!
@@ -145,36 +145,36 @@ public:
 	// apparently caused crash in linux
 	//virtual ~GadgetChain() {}
 	// adds reader gadget
-	void add_reader(std::string id, boost::shared_ptr<aGadget> sptr_g) 
+	void add_reader(std::string id, std::shared_ptr<aGadget> sptr_g) 
 	{
-			readers_.push_back(boost::shared_ptr<GadgetHandle>
+			readers_.push_back(std::shared_ptr<GadgetHandle>
 				(new GadgetHandle(id, sptr_g)));
 	}
 	// adds writer gadget
-	void add_writer(std::string id, boost::shared_ptr<aGadget> sptr_g) 
+	void add_writer(std::string id, std::shared_ptr<aGadget> sptr_g) 
 	{
-		writers_.push_back(boost::shared_ptr<GadgetHandle>
+		writers_.push_back(std::shared_ptr<GadgetHandle>
 			(new GadgetHandle(id, sptr_g)));
 	}
 	// sdds finishig gadget
-	void set_endgadget(boost::shared_ptr<aGadget> sptr_g) 
+	void set_endgadget(std::shared_ptr<aGadget> sptr_g) 
 	{
 		endgadget_ = sptr_g;
 	}
 	// adds any other gadget
-	void add_gadget(std::string id, boost::shared_ptr<aGadget> sptr_g)
+	void add_gadget(std::string id, std::shared_ptr<aGadget> sptr_g)
 	{
-		gadgets_.push_back(boost::shared_ptr<GadgetHandle>
+		gadgets_.push_back(std::shared_ptr<GadgetHandle>
 			(new GadgetHandle(id, sptr_g)));
 	}
-	boost::shared_ptr<aGadget> gadget_sptr(std::string id);
+	std::shared_ptr<aGadget> gadget_sptr(std::string id);
 	// returns string containing the definition of the chain in xml format
 	std::string xml() const;
 private:
-	std::list<boost::shared_ptr<GadgetHandle> > readers_;
-	std::list<boost::shared_ptr<GadgetHandle> > writers_;
-	std::list<boost::shared_ptr<GadgetHandle> > gadgets_;
-	boost::shared_ptr<aGadget> endgadget_;
+	std::list<std::shared_ptr<GadgetHandle> > readers_;
+	std::list<std::shared_ptr<GadgetHandle> > writers_;
+	std::list<std::shared_ptr<GadgetHandle> > gadgets_;
+	std::shared_ptr<aGadget> endgadget_;
 };
 
 class AcquisitionsProcessor : public GadgetChain {
@@ -188,7 +188,7 @@ public:
 		sptr_acqs_.reset();
 		add_reader("reader", reader_);
 		add_writer("writer", writer_);
-		boost::shared_ptr<AcquisitionFinishGadget> 
+		std::shared_ptr<AcquisitionFinishGadget> 
 			endgadget(new AcquisitionFinishGadget);
 		set_endgadget(endgadget);
 	}
@@ -200,7 +200,7 @@ public:
 	}
 
 	void process(AcquisitionsContainer& acquisitions);
-	boost::shared_ptr<AcquisitionsContainer> get_output() 
+	std::shared_ptr<AcquisitionsContainer> get_output() 
 	{
 		return sptr_acqs_;
 	}
@@ -208,9 +208,9 @@ public:
 private:
 	std::string host_;
 	std::string port_;
-	boost::shared_ptr<IsmrmrdAcqMsgReader> reader_;
-	boost::shared_ptr<IsmrmrdAcqMsgWriter> writer_;
-	boost::shared_ptr<AcquisitionsContainer> sptr_acqs_;
+	std::shared_ptr<IsmrmrdAcqMsgReader> reader_;
+	std::shared_ptr<IsmrmrdAcqMsgWriter> writer_;
+	std::shared_ptr<AcquisitionsContainer> sptr_acqs_;
 };
 
 class ImagesReconstructor : public GadgetChain {
@@ -225,7 +225,7 @@ public:
 		sptr_images_.reset();
 		add_reader("reader", reader_);
 		add_writer("writer", writer_);
-		boost::shared_ptr<ImageFinishGadget> endgadget(new ImageFinishGadget);
+		std::shared_ptr<ImageFinishGadget> endgadget(new ImageFinishGadget);
 		set_endgadget(endgadget);
 	}
 	static const char* class_name()
@@ -234,7 +234,7 @@ public:
 	}
 
 	void process(AcquisitionsContainer& acquisitions);
-	boost::shared_ptr<ImagesContainer> get_output() 
+	std::shared_ptr<ImagesContainer> get_output() 
 	{
 		return sptr_images_;
 	}
@@ -242,9 +242,9 @@ public:
 private:
 	std::string host_;
 	std::string port_;
-	boost::shared_ptr<IsmrmrdAcqMsgReader> reader_;
-	boost::shared_ptr<IsmrmrdImgMsgWriter> writer_;
-	boost::shared_ptr<ImagesContainer> sptr_images_;
+	std::shared_ptr<IsmrmrdAcqMsgReader> reader_;
+	std::shared_ptr<IsmrmrdImgMsgWriter> writer_;
+	std::shared_ptr<ImagesContainer> sptr_images_;
 };
 
 class ImagesProcessor : public GadgetChain {
@@ -257,7 +257,7 @@ public:
 		//class_ = "ImagesProcessor";
 		add_reader("reader", reader_);
 		add_writer("writer", writer_);
-		boost::shared_ptr<ImageFinishGadget> endgadget(new ImageFinishGadget);
+		std::shared_ptr<ImageFinishGadget> endgadget(new ImageFinishGadget);
 		set_endgadget(endgadget);
 	}
 	static const char* class_name()
@@ -266,7 +266,7 @@ public:
 	}
 
 	void process(ImagesContainer& images);
-	boost::shared_ptr<ImagesContainer> get_output() 
+	std::shared_ptr<ImagesContainer> get_output() 
 	{
 		return sptr_images_;
 	}
@@ -274,22 +274,22 @@ public:
 private:
 	std::string host_;
 	std::string port_;
-	boost::shared_ptr<IsmrmrdImgMsgReader> reader_;
-	boost::shared_ptr<IsmrmrdImgMsgWriter> writer_;
-	boost::shared_ptr<ImagesContainer> sptr_images_;
+	std::shared_ptr<IsmrmrdImgMsgReader> reader_;
+	std::shared_ptr<IsmrmrdImgMsgWriter> writer_;
+	std::shared_ptr<ImagesContainer> sptr_images_;
 };
 
 class AcquisitionModel {
 public:
 
 	AcquisitionModel(
-		boost::shared_ptr<AcquisitionsContainer> sptr_ac,
-		boost::shared_ptr<ImagesContainer> sptr_ic
+		std::shared_ptr<AcquisitionsContainer> sptr_ac,
+		std::shared_ptr<ImagesContainer> sptr_ic
 		) : sptr_acqs_(sptr_ac), sptr_imgs_(sptr_ic)
 	{
 	}
 
-	void setCSMs(boost::shared_ptr<CoilSensitivitiesContainer> sptr_csms)
+	void setCSMs(std::shared_ptr<CoilSensitivitiesContainer> sptr_csms)
 	{
 		sptr_csms_ = sptr_csms;
 	}
@@ -315,12 +315,12 @@ public:
 	void bwd(ImagesContainer& ic, CoilSensitivitiesContainer& cc,
 		AcquisitionsContainer& ac);
 
-	boost::shared_ptr<AcquisitionsContainer> fwd(ImagesContainer& ic)
+	std::shared_ptr<AcquisitionsContainer> fwd(ImagesContainer& ic)
 	{
 		if (!sptr_csms_.get() || sptr_csms_->items() < 1)
 			throw LocalisedException
 			("coil sensitivity maps not found", __FILE__, __LINE__);
-		boost::shared_ptr<AcquisitionsContainer> sptr_acqs = 
+		std::shared_ptr<AcquisitionsContainer> sptr_acqs = 
 			//AcquisitionsContainerTemplate::new_acquisitions_container();
 			sptr_acqs_->new_acquisitions_container();
 		sptr_acqs->copy_acquisitions_info(*sptr_acqs_);
@@ -328,12 +328,12 @@ public:
 		return sptr_acqs;
 	}
 
-	boost::shared_ptr<ImagesContainer> bwd(AcquisitionsContainer& ac)
+	std::shared_ptr<ImagesContainer> bwd(AcquisitionsContainer& ac)
 	{
 		if (!sptr_csms_.get() || sptr_csms_->items() < 1)
 			throw LocalisedException
 			("coil sensitivity maps not found", __FILE__, __LINE__);
-		boost::shared_ptr<ImagesContainer> sptr_imgs =
+		std::shared_ptr<ImagesContainer> sptr_imgs =
 			sptr_imgs_->new_images_container();
 		bwd(*sptr_imgs, *sptr_csms_, ac);
 		return sptr_imgs;
@@ -341,9 +341,9 @@ public:
 
 private:
 	std::string acqs_info_;
-	boost::shared_ptr<AcquisitionsContainer> sptr_acqs_;
-	boost::shared_ptr<ImagesContainer> sptr_imgs_;
-	boost::shared_ptr<CoilSensitivitiesContainer> sptr_csms_;
+	std::shared_ptr<AcquisitionsContainer> sptr_acqs_;
+	std::shared_ptr<ImagesContainer> sptr_imgs_;
+	std::shared_ptr<CoilSensitivitiesContainer> sptr_csms_;
 
 	template< typename T>
 	void fwd_(ISMRMRD::Image<T>* ptr_img, CoilData& csm,

--- a/src/xSTIR/cSTIR/cstir.cpp
+++ b/src/xSTIR/cSTIR/cstir.cpp
@@ -182,14 +182,14 @@ void* cSTIR_objectFromFile(const char* name, const char* filename)
 			//	(read_from_file<Image3DF>(filename));
 			PETImageData* ptr_id = 
 				new PETImageData(read_from_file<Image3DF>(filename));
-			boost::shared_ptr<PETImageData>* ptr_sptr =
-				new boost::shared_ptr<PETImageData>(ptr_id);
+			std::shared_ptr<PETImageData>* ptr_sptr =
+				new std::shared_ptr<PETImageData>(ptr_id);
 			return newObjectHandle(ptr_sptr);
 		}
 		if (boost::iequals(name, "AcquisitionData")) {
 			//writeText("\nreading ");
 			//writeText(filename);
-			//NEW(boost::shared_ptr<ProjData>, ptr_sptr);
+			//NEW(std::shared_ptr<ProjData>, ptr_sptr);
 			//*ptr_sptr = boost::static_pointer_cast<PETAcquisitionData>
 			//	(ProjData::read_from_file(filename));
 			//writeText("ok\n");
@@ -280,7 +280,7 @@ void* cSTIR_acquisitionModelFwd
 		//sptrProjData* ptr_sptr = new sptrProjData;
 		//*ptr_sptr = am.forward(im, datafile);
 		//return newObjectHandle(ptr_sptr);
-		NEW(boost::shared_ptr<PETAcquisitionData>, sptr_ad);
+		NEW(std::shared_ptr<PETAcquisitionData>, sptr_ad);
 		*sptr_ad = am.forward(im);
 		return newObjectHandle(sptr_ad);
 	}
@@ -658,9 +658,9 @@ void* cSTIR_imageFromAcquisitionData(void* ptr_ad)
 {
 	try {
 		//sptrProjData& sptr_ad = objectSptrFromHandle<ProjData>(ptr_ad);
-		boost::shared_ptr<PETAcquisitionData>& sptr_ad =
+		std::shared_ptr<PETAcquisitionData>& sptr_ad =
 			objectSptrFromHandle<PETAcquisitionData>(ptr_ad);
-		boost::shared_ptr<ProjDataInfo> sptr_adi =
+		std::shared_ptr<ProjDataInfo> sptr_adi =
 			sptr_ad->get_proj_data_info_sptr();
 		//Voxels3DF* ptr_voxels = new Voxels3DF(*sptr_adi);
 		//sptrImage3DF* ptr_sptr = new sptrImage3DF(ptr_voxels);
@@ -844,7 +844,7 @@ cSTIR_mult(float a, const void* ptr_x)
 		CAST_PTR(DataHandle, h_x, ptr_x);
 		aDataContainer<float>& x =
 			objectFromHandle<aDataContainer<float> >(h_x);
-		boost::shared_ptr<aDataContainer<float> > sptr_z =
+		std::shared_ptr<aDataContainer<float> > sptr_z =
 			x.new_data_container();
 		sptr_z->mult(a, x);
 		return sptrObjectHandle<aDataContainer<float> >(sptr_z);
@@ -865,7 +865,7 @@ cSTIR_axpby(
 			objectFromHandle<aDataContainer<float> >(h_x);
 		aDataContainer<float>& y =
 			objectFromHandle<aDataContainer<float> >(h_y);
-		boost::shared_ptr<aDataContainer<float> > sptr_z =
+		std::shared_ptr<aDataContainer<float> > sptr_z =
 			x.new_data_container();
 		sptr_z->axpby(a, x, b, y);
 		return sptrObjectHandle<aDataContainer<float> >(sptr_z);

--- a/src/xSTIR/cSTIR/stir_data_containers.cpp
+++ b/src/xSTIR/cSTIR/stir_data_containers.cpp
@@ -21,8 +21,8 @@ limitations under the License.
 #include "stir_data_containers.h"
 
 //std::string PETAcquisitionData::_storage_scheme;
-boost::shared_ptr<PETAcquisitionData> PETAcquisitionData::_template;
-//boost::shared_ptr<ProjData> PETAcquisitionData::acqs_templ_;
+std::shared_ptr<PETAcquisitionData> PETAcquisitionData::_template;
+//std::shared_ptr<ProjData> PETAcquisitionData::acqs_templ_;
 
 float
 PETAcquisitionData::norm()

--- a/src/xSTIR/cSTIR/stir_data_containers.h
+++ b/src/xSTIR/cSTIR/stir_data_containers.h
@@ -53,7 +53,7 @@ class aDataContainer {
 public:
 	virtual ~aDataContainer() {}
 	//virtual aDataContainer<T>* new_data_container() = 0;
-	virtual boost::shared_ptr<aDataContainer<T> > new_data_container() = 0;
+	virtual std::shared_ptr<aDataContainer<T> > new_data_container() = 0;
 	virtual unsigned int items() = 0;
 	virtual float norm() = 0;
 	virtual T dot(const aDataContainer<T>& dc) = 0;
@@ -113,13 +113,13 @@ public:
 //	{
 //		_data->close_stream();
 //	}
-//	boost::shared_ptr<ProjData> data()
+//	std::shared_ptr<ProjData> data()
 //	{
 //		return _data;
 //	}
 //private:
 //	std::string _filename;
-//	boost::shared_ptr<ProjDataFile> _data;
+//	std::shared_ptr<ProjDataFile> _data;
 //};
 
 class PETAcquisitionData : public aDataContainer < float > {
@@ -139,7 +139,7 @@ public:
 	//	PETAcquisitionData* ptr_ad = new PETAcquisitionData();
 	//	_init();
 	//	if (_storage_scheme[0] == 'm') {
-	//		ptr_ad->_data = boost::shared_ptr<ProjData>
+	//		ptr_ad->_data = std::shared_ptr<ProjData>
 	//			(new ProjDataInMemory(pd.get_exam_info_sptr(),
 	//			pd.get_proj_data_info_sptr()));
 	//		return ptr_ad;
@@ -151,41 +151,41 @@ public:
 	//		return ptr_ad;
 	//	}
 	//}
-	virtual boost::shared_ptr<PETAcquisitionData> new_acquisition_data() = 0;
+	virtual std::shared_ptr<PETAcquisitionData> new_acquisition_data() = 0;
 	//{
-	//	return boost::shared_ptr<PETAcquisitionData>
+	//	return std::shared_ptr<PETAcquisitionData>
 	//		(same_acquisition_data(*data()));
 	//}
-	virtual boost::shared_ptr<aDataContainer<float> > new_data_container() = 0;
+	virtual std::shared_ptr<aDataContainer<float> > new_data_container() = 0;
 	//{
-	//	return boost::shared_ptr<aDataContainer<float> >
+	//	return std::shared_ptr<aDataContainer<float> >
 	//		(same_acquisition_data(*data()));
 	//}
 
 	// ProjData accessor/mutator
-	//virtual boost::shared_ptr<ProjData> data() = 0;
+	//virtual std::shared_ptr<ProjData> data() = 0;
 	//{
 	//	if (_file.get())
 	//		return _file->data();
 	//	else
 	//		return _data;
 	//}
-	//virtual const boost::shared_ptr<ProjData> data() const = 0;
+	//virtual const std::shared_ptr<ProjData> data() const = 0;
 	//{ 
 	//	if (_file.get())
 	//		return _file->data();
 	//	else
 	//		return _data;
 	//}
-	boost::shared_ptr<ProjData> data()
+	std::shared_ptr<ProjData> data()
 	{
 		return _data;
 	}
-	const boost::shared_ptr<ProjData> data() const
+	const std::shared_ptr<ProjData> data() const
 	{
 		return _data;
 	}
-	void set_data(boost::shared_ptr<ProjData> data)
+	void set_data(std::shared_ptr<ProjData> data)
 	{
 		_data = data;
 	}
@@ -194,7 +194,7 @@ public:
 	void fill(float v) { data()->fill(v); }
 	void fill(PETAcquisitionData& ad)
 	{
-		boost::shared_ptr<ProjData> sptr = ad.data();
+		std::shared_ptr<ProjData> sptr = ad.data();
 		data()->fill(*sptr);
 	}
 	void fill_from(const float* d) { data()->fill_from(d); }
@@ -240,11 +240,11 @@ public:
 	{
 		return data()->set_segment(s);
 	}
-	boost::shared_ptr<ExamInfo> get_exam_info_sptr() const
+	std::shared_ptr<ExamInfo> get_exam_info_sptr() const
 	{
 		return data()->get_exam_info_sptr();
 	}
-	boost::shared_ptr<ProjDataInfo> get_proj_data_info_sptr() const
+	std::shared_ptr<ProjDataInfo> get_proj_data_info_sptr() const
 	{
 		return data()->get_proj_data_info_sptr();
 	}
@@ -265,12 +265,12 @@ public:
 	operator const ProjData&() const { return *data(); }
 	//operator ProjData*() { return _data.get(); }
 	//operator const ProjData*() const { return _data.get(); }
-	//operator boost::shared_ptr<ProjData>() { return _data; }
-	//operator const boost::shared_ptr<ProjData>() const { return _data; }
+	//operator std::shared_ptr<ProjData>() { return _data; }
+	//operator const std::shared_ptr<ProjData>() const { return _data; }
 
 protected:
 	//static std::string _storage_scheme;
-	static boost::shared_ptr<PETAcquisitionData> _template;
+	static std::shared_ptr<PETAcquisitionData> _template;
 	//static void _init()
 	//{
 	//	static bool initialized = false;
@@ -280,8 +280,8 @@ protected:
 	//		initialized = true;
 	//	}
 	//}
-	boost::shared_ptr<ProjData> _data;
-	//boost::shared_ptr<ProjDataScratchFile> _file;
+	std::shared_ptr<ProjData> _data;
+	//std::shared_ptr<ProjDataScratchFile> _file;
 };
 
 class PETAcquisitionDataInFile : public PETAcquisitionData {
@@ -334,25 +334,25 @@ public:
 		PETAcquisitionData* ptr_ad = new PETAcquisitionDataInFile(pd);
 		return ptr_ad;
 	}
-	boost::shared_ptr<PETAcquisitionData> new_acquisition_data()
+	std::shared_ptr<PETAcquisitionData> new_acquisition_data()
 	{
 		init();
-		return boost::shared_ptr<PETAcquisitionData>
+		return std::shared_ptr<PETAcquisitionData>
 			(_template->same_acquisition_data(*data()));
 	}
-	boost::shared_ptr<aDataContainer<float> > new_data_container()
+	std::shared_ptr<aDataContainer<float> > new_data_container()
 	{
 		init();
-		return boost::shared_ptr<aDataContainer<float> >
+		return std::shared_ptr<aDataContainer<float> >
 			(_template->same_acquisition_data(*data()));
 	}
 
-	//boost::shared_ptr<ProjData> data()
+	//std::shared_ptr<ProjData> data()
 	//{
 	//	return _data;
 	//	//return _file->data();
 	//}
-	//const boost::shared_ptr<ProjData> data() const
+	//const std::shared_ptr<ProjData> data() const
 	//{
 	//	return _data;
 	//	//return _file->data();
@@ -386,7 +386,7 @@ public:
 	PETAcquisitionDataInMemory() {}
 	PETAcquisitionDataInMemory(const ProjData& pd)
 	{
-		_data = boost::shared_ptr<ProjData>
+		_data = std::shared_ptr<ProjData>
 			(new ProjDataInMemory(pd.get_exam_info_sptr(),
 			pd.get_proj_data_info_sptr()));
 	}
@@ -403,16 +403,16 @@ public:
 		PETAcquisitionData* ptr_ad = new PETAcquisitionDataInMemory(pd);
 		return ptr_ad;
 	}
-	boost::shared_ptr<PETAcquisitionData> new_acquisition_data()
+	std::shared_ptr<PETAcquisitionData> new_acquisition_data()
 	{
 		init();
-		return boost::shared_ptr<PETAcquisitionData>
+		return std::shared_ptr<PETAcquisitionData>
 			(_template->same_acquisition_data(*data()));
 	}
-	boost::shared_ptr<aDataContainer<float> > new_data_container()
+	std::shared_ptr<aDataContainer<float> > new_data_container()
 	{
 		init();
-		return boost::shared_ptr<aDataContainer<float> >
+		return std::shared_ptr<aDataContainer<float> >
 			(_template->same_acquisition_data(*data()));
 	}
 
@@ -439,7 +439,7 @@ public:
 	{
 		_data = ptr;
 	}
-	PETImageData(boost::shared_ptr<Image3DF> ptr)
+	PETImageData(std::shared_ptr<Image3DF> ptr)
 	{
 		_data = ptr;
 	}
@@ -449,13 +449,13 @@ public:
 		ptr_image->_data.reset(_data->get_empty_copy());
 		return ptr_image;
 	}
-	boost::shared_ptr<PETImageData> new_image_data()
+	std::shared_ptr<PETImageData> new_image_data()
 	{
-		return boost::shared_ptr<PETImageData>(same_image_data());
+		return std::shared_ptr<PETImageData>(same_image_data());
 	}
-	boost::shared_ptr<aDataContainer<float> > new_data_container()
+	std::shared_ptr<aDataContainer<float> > new_data_container()
 	{
-		return boost::shared_ptr<aDataContainer<float> >(same_image_data());
+		return std::shared_ptr<aDataContainer<float> >(same_image_data());
 	}
 	unsigned int items()
 	{
@@ -482,7 +482,7 @@ public:
 	{
 		return _data.get();
 	}
-	boost::shared_ptr<Image3DF> data_sptr()
+	std::shared_ptr<Image3DF> data_sptr()
 	{
 		return _data;
 	}
@@ -492,7 +492,7 @@ public:
 	}
 
 protected:
-	boost::shared_ptr<Image3DF> _data;
+	std::shared_ptr<Image3DF> _data;
 };
 
 #endif

--- a/src/xSTIR/cSTIR/stir_types.h
+++ b/src/xSTIR/cSTIR/stir_types.h
@@ -21,7 +21,7 @@ limitations under the License.
 #ifndef STIR_DATA_TYPES
 #define STIR_DATA_TYPES
 
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 #include "stir/DiscretisedDensity.h"
 #include "stir/CartesianCoordinate3D.h"
@@ -56,12 +56,12 @@ limitations under the License.
 USING_NAMESPACE_STIR
 
 typedef DiscretisedDensity<3, float> Image3DF;
-typedef boost::shared_ptr<Image3DF> sptrImage3DF;
-typedef boost::shared_ptr<ProjData> sptrProjData;
+typedef std::shared_ptr<Image3DF> sptrImage3DF;
+typedef std::shared_ptr<ProjData> sptrProjData;
 typedef CartesianCoordinate3D<float> Coord3DF;
 typedef VoxelsOnCartesianGrid<float> Voxels3DF;
-typedef boost::shared_ptr<Voxels3DF> sptrVoxels3DF;
-typedef boost::shared_ptr<Shape3D> sptrShape3D;
+typedef std::shared_ptr<Voxels3DF> sptrVoxels3DF;
+typedef std::shared_ptr<Shape3D> sptrShape3D;
 typedef Reconstruction<Image3DF> Reconstruction3DF;
 typedef IterativeReconstruction<Image3DF> IterativeReconstruction3DF;
 typedef GeneralisedObjectiveFunction<Image3DF> ObjectiveFunction3DF;

--- a/src/xSTIR/cSTIR/stir_x.cpp
+++ b/src/xSTIR/cSTIR/stir_x.cpp
@@ -24,14 +24,14 @@ limitations under the License.
 
 void 
 PETAcquisitionModel::set_bin_efficiency
-(boost::shared_ptr<PETAcquisitionData> sptr_data)
+(std::shared_ptr<PETAcquisitionData> sptr_data)
 {
-	////boost::shared_ptr<ProjData> sptr(new ProjDataInMemory(*sptr_data));
-	//boost::shared_ptr<ProjData> sptr(new ProjDataInMemory(*sptr_data->data()));
+	////std::shared_ptr<ProjData> sptr(new ProjDataInMemory(*sptr_data));
+	//std::shared_ptr<ProjData> sptr(new ProjDataInMemory(*sptr_data->data()));
 	//inv_(sptr.get(), MIN_BIN_EFFICIENCY);
 	//sptr_normalisation_.reset(new BinNormalisationFromProjData(sptr));
 
-	boost::shared_ptr<PETAcquisitionData>
+	std::shared_ptr<PETAcquisitionData>
 		sptr_ad(sptr_data->new_acquisition_data());
 	sptr_ad->inv(MIN_BIN_EFFICIENCY, *sptr_data);
 	sptr_normalisation_.reset
@@ -47,8 +47,8 @@ PETAcquisitionModel::set_bin_efficiency
 
 Succeeded 
 PETAcquisitionModel::set_up(
-	boost::shared_ptr<PETAcquisitionData> sptr_acq,
-	boost::shared_ptr<Image3DF> sptr_image)
+	std::shared_ptr<PETAcquisitionData> sptr_acq,
+	std::shared_ptr<Image3DF> sptr_image)
 {
 	Succeeded s = Succeeded::no;
 	if (sptr_projectors_.get()) {
@@ -60,13 +60,13 @@ PETAcquisitionModel::set_up(
 	return s;
 }
 
-boost::shared_ptr<PETAcquisitionData>
+std::shared_ptr<PETAcquisitionData>
 PETAcquisitionModel::forward(const Image3DF& image)
 {
-	boost::shared_ptr<PETAcquisitionData> sptr_ad;
+	std::shared_ptr<PETAcquisitionData> sptr_ad;
 	sptr_ad = sptr_acq_template_->new_acquisition_data();
 
-	boost::shared_ptr<ProjData> sptr_fd = sptr_ad->data();
+	std::shared_ptr<ProjData> sptr_fd = sptr_ad->data();
 
 	sptr_projectors_->get_forward_projector_sptr()->forward_project
 		(*sptr_fd, image);
@@ -104,10 +104,10 @@ PETAcquisitionModel::forward(const Image3DF& image)
 	return sptr_ad;
 }
 
-boost::shared_ptr<Image3DF> 
+std::shared_ptr<Image3DF> 
 PETAcquisitionModel::backward(ProjData& ad)
 {
-	boost::shared_ptr<Image3DF> sptr_im(sptr_image_template_->clone());
+	std::shared_ptr<Image3DF> sptr_im(sptr_image_template_->clone());
 	sptr_im->fill(0.0);
 
 	if (sptr_normalisation_.get() && !sptr_normalisation_->is_trivial()) {

--- a/src/xSTIR/cSTIR/stir_x.h
+++ b/src/xSTIR/cSTIR/stir_x.h
@@ -41,42 +41,42 @@ public:
 		sptr_normalisation_.reset();
 		sptr_norm_.reset();
 	}
-	void set_projectors(boost::shared_ptr<ProjectorByBinPair> sptr_projectors)
+	void set_projectors(std::shared_ptr<ProjectorByBinPair> sptr_projectors)
 	{
 		sptr_projectors_ = sptr_projectors;
 	}
-	boost::shared_ptr<ProjectorByBinPair> projectors_sptr()
+	std::shared_ptr<ProjectorByBinPair> projectors_sptr()
 	{
 		return sptr_projectors_;
 	}
-	void set_additive_term(boost::shared_ptr<PETAcquisitionData> sptr)
+	void set_additive_term(std::shared_ptr<PETAcquisitionData> sptr)
 	{
 		sptr_add_ = sptr;
 	}
-	boost::shared_ptr<PETAcquisitionData> additive_term_sptr()
+	std::shared_ptr<PETAcquisitionData> additive_term_sptr()
 	{
 		return sptr_add_;
 	}
-	void set_background_term(boost::shared_ptr<PETAcquisitionData> sptr)
+	void set_background_term(std::shared_ptr<PETAcquisitionData> sptr)
 	{
 		sptr_background_ = sptr;
 	}
-	boost::shared_ptr<PETAcquisitionData> background_term_sptr()
+	std::shared_ptr<PETAcquisitionData> background_term_sptr()
 	{
 		return sptr_background_;
 	}
-	void set_normalisation(boost::shared_ptr<BinNormalisation> sptr)
+	void set_normalisation(std::shared_ptr<BinNormalisation> sptr)
 	{
 		sptr_normalisation_ = sptr;
 	}
-	boost::shared_ptr<BinNormalisation> normalisation_sptr()
+	std::shared_ptr<BinNormalisation> normalisation_sptr()
 	{
 		return sptr_normalisation_;
 	}
-	void set_bin_efficiency(boost::shared_ptr<PETAcquisitionData> sptr_data);
-	void set_normalisation(boost::shared_ptr<PETAcquisitionData> sptr_data)
+	void set_bin_efficiency(std::shared_ptr<PETAcquisitionData> sptr_data);
+	void set_normalisation(std::shared_ptr<PETAcquisitionData> sptr_data)
 	{
-		boost::shared_ptr<ProjData> sptr(new ProjDataInMemory(*sptr_data));
+		std::shared_ptr<ProjData> sptr(new ProjDataInMemory(*sptr_data));
 		sptr_normalisation_.reset(new BinNormalisationFromProjData(sptr));
 	}
 	void cancel_background_term()
@@ -103,22 +103,22 @@ public:
 	}
 
 	virtual Succeeded set_up(
-		boost::shared_ptr<PETAcquisitionData> sptr_acq,
-		boost::shared_ptr<Image3DF> sptr_image);
+		std::shared_ptr<PETAcquisitionData> sptr_acq,
+		std::shared_ptr<Image3DF> sptr_image);
 
-	boost::shared_ptr<PETAcquisitionData>
+	std::shared_ptr<PETAcquisitionData>
 		forward(const Image3DF& image);
 
-	boost::shared_ptr<Image3DF> backward(ProjData& ad);
+	std::shared_ptr<Image3DF> backward(ProjData& ad);
 
 protected:
-	boost::shared_ptr<ProjectorByBinPair> sptr_projectors_;
-	boost::shared_ptr<PETAcquisitionData> sptr_acq_template_;
-	boost::shared_ptr<Image3DF> sptr_image_template_;
-	boost::shared_ptr<PETAcquisitionData> sptr_add_;
-	boost::shared_ptr<PETAcquisitionData> sptr_background_;
-	boost::shared_ptr<BinNormalisation> sptr_normalisation_;
-	boost::shared_ptr<PETAcquisitionData> sptr_norm_;
+	std::shared_ptr<ProjectorByBinPair> sptr_projectors_;
+	std::shared_ptr<PETAcquisitionData> sptr_acq_template_;
+	std::shared_ptr<Image3DF> sptr_image_template_;
+	std::shared_ptr<PETAcquisitionData> sptr_add_;
+	std::shared_ptr<PETAcquisitionData> sptr_background_;
+	std::shared_ptr<BinNormalisation> sptr_normalisation_;
+	std::shared_ptr<PETAcquisitionData> sptr_norm_;
 };
 
 class PETAcquisitionModelUsingMatrix : public PETAcquisitionModel {
@@ -127,20 +127,20 @@ class PETAcquisitionModelUsingMatrix : public PETAcquisitionModel {
 	{
 		this->sptr_projectors_.reset(new ProjectorPairUsingMatrix);
 	}
-	void set_matrix(boost::shared_ptr<ProjMatrixByBin> sptr_matrix)
+	void set_matrix(std::shared_ptr<ProjMatrixByBin> sptr_matrix)
 	{
 		sptr_matrix_ = sptr_matrix;
 		((ProjectorPairUsingMatrix*)this->sptr_projectors_.get())->
 			set_proj_matrix_sptr(sptr_matrix);
 	}
-	boost::shared_ptr<ProjMatrixByBin> matrix_sptr()
+	std::shared_ptr<ProjMatrixByBin> matrix_sptr()
 	{
 		return ((ProjectorPairUsingMatrix*)this->sptr_projectors_.get())->
 			get_proj_matrix_sptr();
 	}
 	virtual Succeeded set_up(
-		boost::shared_ptr<PETAcquisitionData> sptr_acq,
-		boost::shared_ptr<Image3DF> sptr_image)
+		std::shared_ptr<PETAcquisitionData> sptr_acq,
+		std::shared_ptr<Image3DF> sptr_image)
 	{
 		if (!sptr_matrix_.get())
 			return Succeeded::no;
@@ -148,12 +148,12 @@ class PETAcquisitionModelUsingMatrix : public PETAcquisitionModel {
 	}
 
 private:
-	boost::shared_ptr<ProjMatrixByBin> sptr_matrix_;
+	std::shared_ptr<ProjMatrixByBin> sptr_matrix_;
 };
 
 typedef PETAcquisitionModel AcqMod3DF;
 typedef PETAcquisitionModelUsingMatrix AcqModUsingMatrix3DF;
-typedef boost::shared_ptr<AcqMod3DF> sptrAcqMod3DF;
+typedef std::shared_ptr<AcqMod3DF> sptrAcqMod3DF;
 
 class xSTIR_GeneralisedPrior3DF : public GeneralisedPrior < Image3DF > {
 public:
@@ -183,7 +183,7 @@ public:
 	void set_input_file(const char* filename) {
 		input_filename = filename;
 	}
-	void set_acquisition_model(boost::shared_ptr<AcqMod3DF> sptr)
+	void set_acquisition_model(std::shared_ptr<AcqMod3DF> sptr)
 	{
 		sptr_am_ = sptr;
 		AcqMod3DF& am = *sptr;
@@ -193,12 +193,12 @@ public:
 		if (am.normalisation_sptr().get())
 			set_normalisation_sptr(am.normalisation_sptr());
 	}
-	boost::shared_ptr<AcqMod3DF> acquisition_model_sptr()
+	std::shared_ptr<AcqMod3DF> acquisition_model_sptr()
 	{
 		return sptr_am_;
 	}
 private:
-	boost::shared_ptr<AcqMod3DF> sptr_am_;
+	std::shared_ptr<AcqMod3DF> sptr_am_;
 };
 
 class xSTIR_IterativeReconstruction3DF :

--- a/src/xSTIR/cSTIR/tests/test1.cpp
+++ b/src/xSTIR/cSTIR/tests/test1.cpp
@@ -96,7 +96,7 @@ void test1()
 
 		filename = path + "my_forward_projection.hs";
 		//filename = "tmp.hs";
-		boost::shared_ptr<ProjData> sptr_ad = ProjData::read_from_file(filename);
+		std::shared_ptr<ProjData> sptr_ad = ProjData::read_from_file(filename);
 		size = sptr_ad->size_all();
 		segments = sptr_ad->get_num_segments();
 		sinos = sptr_ad->get_num_sinograms();
@@ -108,7 +108,7 @@ void test1()
 		std::cout << "tangential positions: " << tangs << '\n';
 		std::cout << "size: " << size << ' ' << sinos*views*tangs << '\n';
 
-		boost::shared_ptr<ProjDataInfo> sptr_pdi = sptr_ad->get_proj_data_info_sptr();
+		std::shared_ptr<ProjDataInfo> sptr_pdi = sptr_ad->get_proj_data_info_sptr();
 		ProjDataInfoCylindrical* ptr_pdic = (ProjDataInfoCylindrical*)sptr_pdi.get();
 		double rs = ptr_pdic->get_ring_spacing();
 		std::cout << "ring spacing: " << rs << '\n';
@@ -116,21 +116,21 @@ void test1()
 		double* acq_data = new double[size];
 		sptr_ad->copy_to(acq_data);
 
-		boost::shared_ptr<ProjData> sptr_a(
+		std::shared_ptr<ProjData> sptr_a(
 			new ProjDataInMemory(sptr_ad->get_exam_info_sptr(),
 			sptr_ad->get_proj_data_info_sptr()));
 		sptr_a->fill(0.05f);
 
-		boost::shared_ptr<ProjData> sptr_b(
+		std::shared_ptr<ProjData> sptr_b(
 			new ProjDataInMemory(sptr_ad->get_exam_info_sptr(),
 			sptr_ad->get_proj_data_info_sptr()));
 		sptr_b->fill(0.05f);
 
-		boost::shared_ptr<ProjData> sptr_nd(
+		std::shared_ptr<ProjData> sptr_nd(
 			new ProjDataInMemory(sptr_ad->get_exam_info_sptr(),
 			sptr_ad->get_proj_data_info_sptr()));
 		sptr_nd->fill(2.0f);
-		boost::shared_ptr<BinNormalisation> sptr_n(
+		std::shared_ptr<BinNormalisation> sptr_n(
 			new BinNormalisationFromProjData(sptr_nd));
 		sptr_n->set_up(sptr_ad->get_proj_data_info_sptr());
 
@@ -139,9 +139,9 @@ void test1()
 		PETAcquisitionModelUsingMatrix<Image3DF> acq_mod;
 		acq_mod.set_matrix(sptr_matrix);
 		acq_mod.set_up(sptr_ad, sptr_image);
-		boost::shared_ptr<ProjectorByBinPair> sptr_ppm = acq_mod.projectors_sptr();
+		std::shared_ptr<ProjectorByBinPair> sptr_ppm = acq_mod.projectors_sptr();
 
-		boost::shared_ptr<ProjData> sptr_fd = acq_mod.forward(image, "tmp1.hs");
+		std::shared_ptr<ProjData> sptr_fd = acq_mod.forward(image, "tmp1.hs");
 		size = sptr_fd->size_all();
 		segments = sptr_fd->get_num_segments();
 		sinos = sptr_fd->get_num_sinograms();

--- a/src/xSTIR/cSTIR/tests/test3.cpp
+++ b/src/xSTIR/cSTIR/tests/test3.cpp
@@ -18,8 +18,8 @@ void test3()
 
 	filename = path + "my_forward_projection.hs";
 	//filename = "tmp.hs";
-	boost::shared_ptr<ProjData> sptr_ad = ProjData::read_from_file(filename);
-	boost::shared_ptr<ProjDataInfo> sptr_adi = sptr_ad->get_proj_data_info_sptr();
+	std::shared_ptr<ProjData> sptr_ad = ProjData::read_from_file(filename);
+	std::shared_ptr<ProjDataInfo> sptr_adi = sptr_ad->get_proj_data_info_sptr();
 	size = sptr_ad->size_all();
 	segments = sptr_ad->get_num_segments();
 	sinos = sptr_ad->get_num_sinograms();
@@ -56,7 +56,7 @@ void test3()
 	acq_mod.set_matrix(sptr_matrix);
 	acq_mod.set_up(sptr_ad, sptr_image);
 
-	//boost::shared_ptr<ProjData> sptr_fd = acq_mod.forward(image);
+	//std::shared_ptr<ProjData> sptr_fd = acq_mod.forward(image);
 
 	//double* acq_data = new double[size];
 	//sptr_ad->copy_to(acq_data);

--- a/src/xSTIR/cSTIR/tests/tests.h
+++ b/src/xSTIR/cSTIR/tests/tests.h
@@ -4,7 +4,7 @@
 #define CAST_REF(T, X, Y) T& X = (T&)Y
 
 #define OBJECT(Base, Obj, X, sptr_X) \
-	boost::shared_ptr< Base > sptr_X(new Obj); Obj& X = (Obj&)*sptr_X
+	std::shared_ptr< Base > sptr_X(new Obj); Obj& X = (Obj&)*sptr_X
 
 #define CATCH \
 	catch (LocalisedException& se) {\


### PR DESCRIPTION
Doesn't compile as STIR still seems to be using `boost::shared_ptr`

- related to https://github.com/CCPPETMR/SIRF/issues/60
- fixes https://github.com/CCPPETMR/SIRF/issues/59
- alternative to https://github.com/CCPPETMR/SIRF-SuperBuild/commit/7478a648184844c65a964dfbab7cc617caff8028
    + need to set `-DSTIR_USE_BOOST_SHARED_PTR=OFF` to test this branch (along with `-DSIRF_TAG=shared_ptr`)
