### PR TITLE
change PETAttenuationModel to be safer

### DIFF
--- a/src/xSTIR/cSTIR/stir_x.h
+++ b/src/xSTIR/cSTIR/stir_x.h
@@ -450,7 +450,7 @@ public:
 	// divide by bin efficiencies
 	virtual void normalise(PETAcquisitionData& ad) const;
 protected:
-	shared_ptr<ProjectorByBinPair> sptr_projectors_;
+	shared_ptr<ForwardProjectorByBin> sptr_forw_projector_;
 };
 
 /*!


### PR DESCRIPTION
- only store the forward projector (not the pair) such that set_up and data_symmetries are always correct
- check explicitly if forward projector is set (this can currently happen in STIR when using a matrix if you didn't call set_up yet)