### PR TITLE
Fix for my broken SETUP_PY installation. Now I can use PYTHONPATH.

### DIFF
--- a/cmake/setup.py.cmake
+++ b/cmake/setup.py.cmake
@@ -31,18 +31,19 @@ if(BUILD_PYTHON)
   configure_file("${SETUP_PY_IN}" "${SETUP_PY}")
 
   if(PYTHONINTERP_FOUND)
-    # python setup.py build
-    add_custom_command(OUTPUT "${SETUP_PY_INIT}"
-      COMMAND "${CMAKE_COMMAND}" -E make_directory "${PYTHON_DEST}/sirf"
-      COMMAND "${CMAKE_COMMAND}" -E touch "${SETUP_PY_INIT}"
-      COMMAND "${PYTHON_EXECUTABLE}" setup.py build
-      DEPENDS "${SETUP_PY}"
-      WORKING_DIRECTORY "${PYTHON_DEST}")
-
-    add_custom_target(pybuild_sirf ALL DEPENDS "${SETUP_PY_INIT}")
-
-    # python setup.py install
     if("${PYTHON_STRATEGY}" STREQUAL "SETUP_PY")
+      # python setup.py build
+      add_custom_command(OUTPUT "${SETUP_PY_INIT}"
+        COMMAND "${CMAKE_COMMAND}" -E make_directory "${PYTHON_DEST}/sirf"
+        COMMAND "${CMAKE_COMMAND}" -E touch "${SETUP_PY_INIT}"
+        COMMAND "${PYTHON_EXECUTABLE}" setup.py build
+        DEPENDS "${SETUP_PY}"
+        WORKING_DIRECTORY "${PYTHON_DEST}")
+
+      add_custom_target(pybuild_sirf ALL DEPENDS "${SETUP_PY_INIT}")
+
+      # python setup.py install
+      message(STATUS "setup.py:Running")
       install(CODE "execute_process(COMMAND\n\
         \"${PYTHON_EXECUTABLE}\" setup.py install\n\
         WORKING_DIRECTORY \"${PYTHON_DEST}\")")


### PR DESCRIPTION
For me, running setup.py currently fails (TODO: create an issue).

However, it shouldn't be run if using PYTHONPATH. Now the SETUP_PY_INIT is only run if method is SETUP_PY.