### PR TITLE
Resolves namespace ambiguity in use of shared_ptr

### DIFF
--- a/src/xSTIR/cSTIR/cstir.cpp
+++ b/src/xSTIR/cSTIR/cstir.cpp
@@ -26,7 +26,7 @@ limitations under the License.
 #include "stir_x.h"
 #include "stir_data_containers.h"
 
-using stir::shared_ptr;
+using namespace stir;
 
 static void*
 unknownObject(const char* obj, const char* name, const char* file, int line)

--- a/src/xSTIR/cSTIR/cstir_p.cpp
+++ b/src/xSTIR/cSTIR/cstir_p.cpp
@@ -27,10 +27,10 @@ limitations under the License.
 #include "stir_x.h"
 #include "stir_data_containers.h"
 
+using namespace stir;
+
 extern "C"
 char* charDataFromHandle(const void* ptr);
-
-using stir::shared_ptr;
 
 static void*
 parameterNotFound(const char* name, const char* file, int line) 

--- a/src/xSTIR/cSTIR/stir_data_containers.cpp
+++ b/src/xSTIR/cSTIR/stir_data_containers.cpp
@@ -19,8 +19,7 @@ limitations under the License.
 */
 
 #include "stir_data_containers.h"
-
-using stir::shared_ptr;
+using namespace stir;
 
 std::string PETAcquisitionData::_storage_scheme;
 shared_ptr<PETAcquisitionData> PETAcquisitionData::_template;

--- a/src/xSTIR/cSTIR/stir_data_containers.h
+++ b/src/xSTIR/cSTIR/stir_data_containers.h
@@ -40,7 +40,6 @@ limitations under the License.
 #include "stir_types.h"
 #include "SIRF/common/data_container.h"
 
-// using stir::stir::shared_ptr;
 
 class SIRFUtilities {
 public:
@@ -63,7 +62,7 @@ public:
 
 /*!
 \ingroup STIR Extensions
-\brief STIR stir::ProjDataInterfile wrapper with additional file managing features.
+\brief STIR ProjDataInterfile wrapper with additional file managing features.
 
 This derived class has additional capability of deleting the file it handles
 when an object of this class goes out of existence.
@@ -122,9 +121,9 @@ private:
 
 /*!
 \ingroup STIR Extensions
-\brief STIR stir::ProjData wrapper with added functionality.
+\brief STIR ProjData wrapper with added functionality.
 
-This class enjoys some features of STIR stir::ProjData and, additionally,
+This class enjoys some features of STIR ProjData and, additionally,
 implements the linear algebra functionality specified by the
 abstract base class aDatacontainer, and provides means for the data
 storage mode (file/memory) selection.
@@ -213,7 +212,7 @@ public:
 	void axpby(float a, const aDataContainer<float>& x,
 		float b, const aDataContainer<float>& y);
 
-	// stir::ProjData methods
+	// ProjData methods
 	int get_num_tangential_poss()
 	{
 		return data()->get_num_tangential_poss();
@@ -253,7 +252,7 @@ public:
 		return data()->get_proj_data_info_sptr();
 	}
 
-	// stir::ProjData casts
+	// ProjData casts
 	operator stir::ProjData&() { return *data(); }
 	operator const stir::ProjData&() const { return *data(); }
 	operator stir::shared_ptr<stir::ProjData>() { return data(); }

--- a/src/xSTIR/cSTIR/stir_data_containers.h
+++ b/src/xSTIR/cSTIR/stir_data_containers.h
@@ -40,7 +40,7 @@ limitations under the License.
 #include "stir_types.h"
 #include "SIRF/common/data_container.h"
 
-using stir::shared_ptr;
+// using stir::stir::shared_ptr;
 
 class SIRFUtilities {
 public:
@@ -63,25 +63,26 @@ public:
 
 /*!
 \ingroup STIR Extensions
-\brief STIR ProjDataInterfile wrapper with additional file managing features.
+\brief STIR stir::ProjDataInterfile wrapper with additional file managing features.
 
 This derived class has additional capability of deleting the file it handles
 when an object of this class goes out of existence.
 */
 
-class ProjDataFile : public ProjDataInterfile {
+class ProjDataFile : public stir::ProjDataInterfile {
+
 public:
-	ProjDataFile(const ProjData& pd, const std::string& filename, bool owns_file = true) :
-		ProjDataInterfile(pd.get_exam_info_sptr(),
+	ProjDataFile(const stir::ProjData& pd, const std::string& filename, bool owns_file = true) :
+		stir::ProjDataInterfile(pd.get_exam_info_sptr(),
 		pd.get_proj_data_info_sptr(),
 		filename, std::ios::in | std::ios::out | std::ios::trunc),
 		_filename(filename),
 		_owns_file(owns_file)
 	{}
-	ProjDataFile(shared_ptr<ExamInfo> sptr_exam_info, 
-		shared_ptr<ProjDataInfo> sptr_proj_data_info, 
+	ProjDataFile(stir::shared_ptr<stir::ExamInfo> sptr_exam_info, 
+		stir::shared_ptr<stir::ProjDataInfo> sptr_proj_data_info, 
 		const std::string& filename, bool owns_file = true) :
-		ProjDataInterfile(sptr_exam_info, sptr_proj_data_info,
+		stir::ProjDataInterfile(sptr_exam_info, sptr_proj_data_info,
 		filename, std::ios::in | std::ios::out | std::ios::trunc),
 		_filename(filename),
 		_owns_file(owns_file)
@@ -102,7 +103,7 @@ public:
 			std::cout << "deleting " << _filename << ".s "
 			<< "failed, please delete manually" << std::endl;
 	}
-	shared_ptr<std::iostream> sino_stream_sptr()
+	stir::shared_ptr<std::iostream> sino_stream_sptr()
 	{
 		return sino_stream;
 	}
@@ -121,9 +122,9 @@ private:
 
 /*!
 \ingroup STIR Extensions
-\brief STIR ProjData wrapper with added functionality.
+\brief STIR stir::ProjData wrapper with added functionality.
 
-This class enjoys some features of STIR ProjData and, additionally,
+This class enjoys some features of STIR stir::ProjData and, additionally,
 implements the linear algebra functionality specified by the
 abstract base class aDatacontainer, and provides means for the data
 storage mode (file/memory) selection.
@@ -135,16 +136,16 @@ public:
 
 	// virtual constructors
 	virtual PETAcquisitionData* same_acquisition_data
-		(shared_ptr<ExamInfo> sptr_exam_info,
-		shared_ptr<ProjDataInfo> sptr_proj_data_info) = 0;
-	virtual PETAcquisitionData* same_acquisition_data(const ProjData& pd) = 0;
+		(stir::shared_ptr<stir::ExamInfo> sptr_exam_info,
+		stir::shared_ptr<stir::ProjDataInfo> sptr_proj_data_info) = 0;
+	virtual PETAcquisitionData* same_acquisition_data(const stir::ProjData& pd) = 0;
 	virtual PETAcquisitionData* same_acquisition_data
-		(shared_ptr<ExamInfo> sptr_ei, std::string scanner_name,
+		(stir::shared_ptr<stir::ExamInfo> sptr_ei, std::string scanner_name,
 		int span = 1, int max_ring_diff = -1, int view_mash_factor = 1) = 0;
-	virtual shared_ptr<PETAcquisitionData> new_acquisition_data() = 0;
+	virtual stir::shared_ptr<PETAcquisitionData> new_acquisition_data() = 0;
 	virtual aDataContainer<float>* new_data_container() = 0;
 
-	shared_ptr<PETAcquisitionData> single_slice_rebinned_data(
+	stir::shared_ptr<PETAcquisitionData> single_slice_rebinned_data(
 		const int num_segments_to_combine,
 		const int num_views_to_combine = 1,
 		const int num_tang_poss_to_trim = 0,
@@ -152,14 +153,14 @@ public:
 		const int max_in_segment_num_to_process = -1
 		)
 	{
-		shared_ptr<ProjDataInfo> out_proj_data_info_sptr(
-			SSRB(*data()->get_proj_data_info_ptr(),
+		stir::shared_ptr<stir::ProjDataInfo> out_proj_data_info_sptr(
+			stir::SSRB(*data()->get_proj_data_info_ptr(),
 			num_segments_to_combine,
 			num_views_to_combine,
 			num_tang_poss_to_trim,
 			max_in_segment_num_to_process
 			));
-		shared_ptr<PETAcquisitionData> sptr(same_acquisition_data
+		stir::shared_ptr<PETAcquisitionData> sptr(same_acquisition_data
 			(data()->get_exam_info_sptr(), out_proj_data_info_sptr));
 		SSRB(*sptr, *data(), do_normalisation);
 		return sptr;
@@ -175,15 +176,15 @@ public:
 		return _storage_scheme;
 	}
 
-	shared_ptr<ProjData> data()
+	stir::shared_ptr<stir::ProjData> data()
 	{
 		return _data;
 	}
-	const shared_ptr<ProjData> data() const
+	const stir::shared_ptr<stir::ProjData> data() const
 	{
 		return _data;
 	}
-	void set_data(shared_ptr<ProjData> data)
+	void set_data(stir::shared_ptr<stir::ProjData> data)
 	{
 		_data = data;
 	}
@@ -192,7 +193,7 @@ public:
 	void fill(float v) { data()->fill(v); }
 	void fill(PETAcquisitionData& ad)
 	{
-		shared_ptr<ProjData> sptr = ad.data();
+		stir::shared_ptr<stir::ProjData> sptr = ad.data();
 		data()->fill(*sptr);
 	}
 	void fill_from(const float* d) { data()->fill_from(d); }
@@ -212,7 +213,7 @@ public:
 	void axpby(float a, const aDataContainer<float>& x,
 		float b, const aDataContainer<float>& y);
 
-	// ProjData methods
+	// stir::ProjData methods
 	int get_num_tangential_poss()
 	{
 		return data()->get_num_tangential_poss();
@@ -229,44 +230,44 @@ public:
 	{
 		return data()->get_max_segment_num();
 	}
-	SegmentBySinogram<float>
+	stir::SegmentBySinogram<float>
 		get_segment_by_sinogram(const int segment_num) const
 	{
 		return data()->get_segment_by_sinogram(segment_num);
 	}
-	SegmentBySinogram<float>
+	stir::SegmentBySinogram<float>
 		get_empty_segment_by_sinogram(const int segment_num) const
 	{
 		return data()->get_empty_segment_by_sinogram(segment_num);
 	}
-	virtual Succeeded set_segment(const SegmentBySinogram<float>& s)
+	virtual stir::Succeeded set_segment(const stir::SegmentBySinogram<float>& s)
 	{
 		return data()->set_segment(s);
 	}
-	shared_ptr<ExamInfo> get_exam_info_sptr() const
+	stir::shared_ptr<stir::ExamInfo> get_exam_info_sptr() const
 	{
 		return data()->get_exam_info_sptr();
 	}
-	shared_ptr<ProjDataInfo> get_proj_data_info_sptr() const
+	stir::shared_ptr<stir::ProjDataInfo> get_proj_data_info_sptr() const
 	{
 		return data()->get_proj_data_info_sptr();
 	}
 
-	// ProjData casts
-	operator ProjData&() { return *data(); }
-	operator const ProjData&() const { return *data(); }
-	operator shared_ptr<ProjData>() { return data(); }
+	// stir::ProjData casts
+	operator stir::ProjData&() { return *data(); }
+	operator const stir::ProjData&() const { return *data(); }
+	operator stir::shared_ptr<stir::ProjData>() { return data(); }
 
 protected:
 	static std::string _storage_scheme;
-	static shared_ptr<PETAcquisitionData> _template;
-	shared_ptr<ProjData> _data;
+	static stir::shared_ptr<PETAcquisitionData> _template;
+	stir::shared_ptr<stir::ProjData> _data;
 
-	static shared_ptr<ProjDataInfo> 
+	static stir::shared_ptr<stir::ProjDataInfo> 
 		proj_data_info_from_scanner(std::string scanner_name,
 		int span = 1, int max_ring_diff = -1, int view_mash_factor = 1)
 	{
-		shared_ptr<Scanner> sptr_s(Scanner::get_scanner_from_name(scanner_name));
+		stir::shared_ptr<stir::Scanner> sptr_s(stir::Scanner::get_scanner_from_name(scanner_name));
 		//std::cout << "scanner: " << sptr_s->get_name().c_str() << '\n';
 		if (boost::iequals(sptr_s->get_name(), "unknown")) {
 			throw LocalisedException("Unknown scanner", __FILE__, __LINE__);
@@ -275,7 +276,7 @@ protected:
 		int num_tang_pos = sptr_s->get_max_num_non_arccorrected_bins();
 		if (max_ring_diff < 0)
 			max_ring_diff = sptr_s->get_num_rings() - 1;
-		return std::move(ProjDataInfo::construct_proj_data_info
+		return std::move(stir::ProjDataInfo::construct_proj_data_info
 			(sptr_s, span, max_ring_diff, num_views, num_tang_pos, false));
 	}
 };
@@ -291,25 +292,25 @@ public:
 	PETAcquisitionDataInFile() : _owns_file(false) {}
 	PETAcquisitionDataInFile(const char* filename) : _owns_file(false)
 	{
-		_data = ProjData::read_from_file(filename);
+		_data = stir::ProjData::read_from_file(filename);
 	}
-	PETAcquisitionDataInFile(shared_ptr<ExamInfo> sptr_exam_info,
-		shared_ptr<ProjDataInfo> sptr_proj_data_info)
+	PETAcquisitionDataInFile(stir::shared_ptr<stir::ExamInfo> sptr_exam_info,
+		stir::shared_ptr<stir::ProjDataInfo> sptr_proj_data_info)
 	{
 		_data.reset(new ProjDataFile
 			(sptr_exam_info, sptr_proj_data_info, 
 			_filename = SIRFUtilities::scratch_file_name()));
 	}
-	PETAcquisitionDataInFile(const ProjData& pd) : _owns_file(true)
+	PETAcquisitionDataInFile(const stir::ProjData& pd) : _owns_file(true)
 	{
 		_data.reset(new ProjDataFile
 		(pd, _filename = SIRFUtilities::scratch_file_name()));
 	}
 	PETAcquisitionDataInFile
-		(shared_ptr<ExamInfo> sptr_ei, std::string scanner_name,
+		(stir::shared_ptr<stir::ExamInfo> sptr_ei, std::string scanner_name,
 		int span = 1, int max_ring_diff = -1, int view_mash_factor = 1)
 	{
-		shared_ptr<ProjDataInfo> sptr_pdi =
+		stir::shared_ptr<stir::ProjDataInfo> sptr_pdi =
 			PETAcquisitionData::proj_data_info_from_scanner
 			(scanner_name, span, max_ring_diff, view_mash_factor);
 		ProjDataFile* ptr = new ProjDataFile(sptr_ei, sptr_pdi,
@@ -317,9 +318,9 @@ public:
 		ptr->fill(0.0f);
 		_data.reset(ptr);
 	}
-	shared_ptr<PETAcquisitionData> new_acquisition_data(std::string filename)
+	stir::shared_ptr<PETAcquisitionData> new_acquisition_data(std::string filename)
 	{
-		shared_ptr<PETAcquisitionDataInFile> sptr_ad(new PETAcquisitionDataInFile);
+		stir::shared_ptr<PETAcquisitionDataInFile> sptr_ad(new PETAcquisitionDataInFile);
 		sptr_ad->_data.reset(new ProjDataFile(*data(), filename, false));
 		return sptr_ad;
 	}
@@ -341,30 +342,30 @@ public:
 	}
 
 	virtual PETAcquisitionData* same_acquisition_data
-		(shared_ptr<ExamInfo> sptr_exam_info,
-		shared_ptr<ProjDataInfo> sptr_proj_data_info)
+		(stir::shared_ptr<stir::ExamInfo> sptr_exam_info,
+		stir::shared_ptr<stir::ProjDataInfo> sptr_proj_data_info)
 	{
 		PETAcquisitionData* ptr_ad = 
 			new PETAcquisitionDataInFile(sptr_exam_info, sptr_proj_data_info);
 		return ptr_ad;
 	}
-	virtual PETAcquisitionData* same_acquisition_data(const ProjData& pd)
+	virtual PETAcquisitionData* same_acquisition_data(const stir::ProjData& pd)
 	{
 		PETAcquisitionData* ptr_ad = new PETAcquisitionDataInFile(pd);
 		return ptr_ad;
 	}
 	virtual PETAcquisitionData* same_acquisition_data
-		(shared_ptr<ExamInfo> sptr_ei, std::string scanner_name,
+		(stir::shared_ptr<stir::ExamInfo> sptr_ei, std::string scanner_name,
 		int span = 1, int max_ring_diff = -1, int view_mash_factor = 1)
 	{
 		PETAcquisitionData* ptr_ad = new PETAcquisitionDataInFile
 			(sptr_ei, scanner_name, span, max_ring_diff, view_mash_factor);
 		return ptr_ad;
 	}
-	virtual shared_ptr<PETAcquisitionData> new_acquisition_data()
+	virtual stir::shared_ptr<PETAcquisitionData> new_acquisition_data()
 	{
 		init();
-		return shared_ptr<PETAcquisitionData>
+		return stir::shared_ptr<PETAcquisitionData>
 			(_template->same_acquisition_data(*data()));
 	}
 	virtual aDataContainer<float>* new_data_container()
@@ -387,26 +388,26 @@ private:
 class PETAcquisitionDataInMemory : public PETAcquisitionData {
 public:
 	PETAcquisitionDataInMemory() {}
-	PETAcquisitionDataInMemory(shared_ptr<ExamInfo> sptr_exam_info,
-		shared_ptr<ProjDataInfo> sptr_proj_data_info)
+	PETAcquisitionDataInMemory(stir::shared_ptr<stir::ExamInfo> sptr_exam_info,
+		stir::shared_ptr<stir::ProjDataInfo> sptr_proj_data_info)
 	{
-		_data = shared_ptr<ProjData>
-			(new ProjDataInMemory(sptr_exam_info, sptr_proj_data_info));
+		_data = stir::shared_ptr<stir::ProjData>
+			(new stir::ProjDataInMemory(sptr_exam_info, sptr_proj_data_info));
 	}
-	PETAcquisitionDataInMemory(const ProjData& pd)
+	PETAcquisitionDataInMemory(const stir::ProjData& pd)
 	{
-		_data = shared_ptr<ProjData>
-			(new ProjDataInMemory(pd.get_exam_info_sptr(),
+		_data = stir::shared_ptr<stir::ProjData>
+			(new stir::ProjDataInMemory(pd.get_exam_info_sptr(),
 			pd.get_proj_data_info_sptr()));
 	}
 	PETAcquisitionDataInMemory
-		(shared_ptr<ExamInfo> sptr_ei, std::string scanner_name,
+		(stir::shared_ptr<stir::ExamInfo> sptr_ei, std::string scanner_name,
 		int span = 1, int max_ring_diff = -1, int view_mash_factor = 1)
 	{
-		shared_ptr<ProjDataInfo> sptr_pdi =
+		stir::shared_ptr<stir::ProjDataInfo> sptr_pdi =
 			PETAcquisitionData::proj_data_info_from_scanner
 			(scanner_name, span, max_ring_diff, view_mash_factor);
-		ProjDataInMemory* ptr = new ProjDataInMemory(sptr_ei, sptr_pdi);
+		stir::ProjDataInMemory* ptr = new stir::ProjDataInMemory(sptr_ei, sptr_pdi);
 		ptr->fill(0.0f);
 		_data.reset(ptr);
 	}
@@ -420,30 +421,30 @@ public:
 	}
 
 	virtual PETAcquisitionData* same_acquisition_data
-		(shared_ptr<ExamInfo> sptr_exam_info,
-		shared_ptr<ProjDataInfo> sptr_proj_data_info)
+		(stir::shared_ptr<stir::ExamInfo> sptr_exam_info,
+		stir::shared_ptr<stir::ProjDataInfo> sptr_proj_data_info)
 	{
 		PETAcquisitionData* ptr_ad =
 			new PETAcquisitionDataInMemory(sptr_exam_info, sptr_proj_data_info);
 		return ptr_ad;
 	}
-	virtual PETAcquisitionData* same_acquisition_data(const ProjData& pd)
+	virtual PETAcquisitionData* same_acquisition_data(const stir::ProjData& pd)
 	{
 		PETAcquisitionData* ptr_ad = new PETAcquisitionDataInMemory(pd);
 		return ptr_ad;
 	}
 	virtual PETAcquisitionData* same_acquisition_data
-		(shared_ptr<ExamInfo> sptr_ei, std::string scanner_name,
+		(stir::shared_ptr<stir::ExamInfo> sptr_ei, std::string scanner_name,
 		int span = 1, int max_ring_diff = -1, int view_mash_factor = 1)
 	{
 		PETAcquisitionData* ptr_ad = new PETAcquisitionDataInMemory
 			(sptr_ei, scanner_name, span, max_ring_diff, view_mash_factor);
 		return ptr_ad;
 	}
-	virtual shared_ptr<PETAcquisitionData> new_acquisition_data()
+	virtual stir::shared_ptr<PETAcquisitionData> new_acquisition_data()
 	{
 		init();
-		return shared_ptr<PETAcquisitionData>
+		return stir::shared_ptr<PETAcquisitionData>
 			(_template->same_acquisition_data(*data()));
 	}
 	virtual aDataContainer<float>* new_data_container()
@@ -482,17 +483,17 @@ public:
 	{
 		_data.reset(v.clone());
 	}
-	PETImageData(const ProjDataInfo& pdi)
+	PETImageData(const stir::ProjDataInfo& pdi)
 	{
 		_data.reset(new Voxels3DF(pdi));
 	}
-	PETImageData(shared_ptr<Image3DF> ptr)
+	PETImageData(stir::shared_ptr<Image3DF> ptr)
 	{
 		_data = ptr;
 	}
 	PETImageData(std::string filename)
 	{
-		_data = read_from_file<Image3DF>(filename);
+		_data = stir::read_from_file<Image3DF>(filename);
 	}
 	PETImageData* same_image_data()
 	{
@@ -500,9 +501,9 @@ public:
 		ptr_image->_data.reset(_data->get_empty_copy());
 		return ptr_image;
 	}
-	shared_ptr<PETImageData> new_image_data()
+	stir::shared_ptr<PETImageData> new_image_data()
 	{
-		return shared_ptr<PETImageData>(same_image_data());
+		return stir::shared_ptr<PETImageData>(same_image_data());
 	}
 	aDataContainer<float>* new_data_container()
 	{
@@ -533,11 +534,11 @@ public:
 	{
 		return _data.get();
 	}
-	shared_ptr<Image3DF> data_sptr()
+	stir::shared_ptr<Image3DF> data_sptr()
 	{
 		return _data;
 	}
-	void set_data_sptr(shared_ptr<Image3DF> sptr_data)
+	void set_data_sptr(stir::shared_ptr<Image3DF> sptr_data)
 	{
 		_data = sptr_data;
 	}
@@ -551,7 +552,7 @@ public:
 	int set_data(const float* data);
 
 protected:
-	shared_ptr<Image3DF> _data;
+	stir::shared_ptr<Image3DF> _data;
 };
 
 #endif

--- a/src/xSTIR/cSTIR/stir_types.h
+++ b/src/xSTIR/cSTIR/stir_types.h
@@ -64,10 +64,6 @@ limitations under the License.
 
 #define GRAB 1
 
-// using stir::shared_ptr;
-
-// USING_NAMESPACE_STIR
-// USING_NAMESPACE_ECAT
 
 typedef stir::DiscretisedDensity<3, float> Image3DF;
 typedef stir::shared_ptr<Image3DF> sptrImage3DF;

--- a/src/xSTIR/cSTIR/stir_types.h
+++ b/src/xSTIR/cSTIR/stir_types.h
@@ -64,29 +64,29 @@ limitations under the License.
 
 #define GRAB 1
 
-using stir::shared_ptr;
+// using stir::shared_ptr;
 
-USING_NAMESPACE_STIR
-USING_NAMESPACE_ECAT
+// USING_NAMESPACE_STIR
+// USING_NAMESPACE_ECAT
 
-typedef DiscretisedDensity<3, float> Image3DF;
-typedef shared_ptr<Image3DF> sptrImage3DF;
-typedef shared_ptr<ProjData> sptrProjData;
-typedef CartesianCoordinate3D<float> Coord3DF;
-typedef VoxelsOnCartesianGrid<float> Voxels3DF;
-typedef shared_ptr<Voxels3DF> sptrVoxels3DF;
-typedef shared_ptr<Shape3D> sptrShape3D;
-typedef Reconstruction<Image3DF> Reconstruction3DF;
-typedef IterativeReconstruction<Image3DF> IterativeReconstruction3DF;
-typedef GeneralisedObjectiveFunction<Image3DF> ObjectiveFunction3DF;
-typedef PoissonLogLikelihoodWithLinearModelForMean<Image3DF>
+typedef stir::DiscretisedDensity<3, float> Image3DF;
+typedef stir::shared_ptr<Image3DF> sptrImage3DF;
+typedef stir::shared_ptr<stir::ProjData> sptrProjData;
+typedef stir::CartesianCoordinate3D<float> Coord3DF;
+typedef stir::VoxelsOnCartesianGrid<float> Voxels3DF;
+typedef stir::shared_ptr<Voxels3DF> sptrVoxels3DF;
+typedef stir::shared_ptr<stir::Shape3D> sptrShape3D;
+typedef stir::Reconstruction<Image3DF> Reconstruction3DF;
+typedef stir::IterativeReconstruction<Image3DF> IterativeReconstruction3DF;
+typedef stir::GeneralisedObjectiveFunction<Image3DF> ObjectiveFunction3DF;
+typedef stir::PoissonLogLikelihoodWithLinearModelForMean<Image3DF>
 PoissonLogLhLinModMean3DF;
 //PoissonLogLikelihoodWithLinearModelForMeanAndProjData<Image3DF>
-typedef ProjectorByBinPairUsingProjMatrixByBin ProjectorPairUsingMatrix;
-typedef ProjMatrixByBinUsingRayTracing RayTracingMatrix;
-typedef GeneralisedPrior<Image3DF> Prior3DF;
-typedef QuadraticPrior<float> QuadPrior3DF;
-typedef DataProcessor<Image3DF> DataProcessor3DF;
-typedef TruncateToCylindricalFOVImageProcessor<float> CylindricFilter3DF;
+typedef stir::ProjectorByBinPairUsingProjMatrixByBin ProjectorPairUsingMatrix;
+typedef stir::ProjMatrixByBinUsingRayTracing RayTracingMatrix;
+typedef stir::GeneralisedPrior<Image3DF> Prior3DF;
+typedef stir::QuadraticPrior<float> QuadPrior3DF;
+typedef stir::DataProcessor<Image3DF> DataProcessor3DF;
+typedef stir::TruncateToCylindricalFOVImageProcessor<float> CylindricFilter3DF;
 
 #endif

--- a/src/xSTIR/cSTIR/stir_x.cpp
+++ b/src/xSTIR/cSTIR/stir_x.cpp
@@ -24,7 +24,8 @@ limitations under the License.
 #include "stir/is_null_ptr.h"
 #include "stir/error.h"
 
-using stir::shared_ptr;
+using namespace stir;
+USING_NAMESPACE_ECAT
 
 void
 ListmodeToSinograms::compute_fan_sums_(bool prompt_fansum)

--- a/src/xSTIR/cSTIR/stir_x.h
+++ b/src/xSTIR/cSTIR/stir_x.h
@@ -73,7 +73,7 @@ The actual algorithm is described in
 > [Online](http://dx.doi.org/10.1109/nssmic.2002.1239610).
 */
 
-class ListmodeToSinograms : public LmToProjData {
+class ListmodeToSinograms : public stir::LmToProjData {
 public:
 	//! Constructor. 
     /*! Takes an optional text string argument with
@@ -85,9 +85,9 @@ public:
         
         By default, `store_prompts` is `true` and `store_delayeds` is `false`.
 	*/
-	//ListmodeToSinograms(const char* const par) : LmToProjData(par) {}
-	ListmodeToSinograms(const char* par) : LmToProjData(par) {}
-	ListmodeToSinograms() : LmToProjData()
+	//ListmodeToSinograms(const char* const par) : stir::LmToProjData(par) {}
+	ListmodeToSinograms(const char* par) : stir::LmToProjData(par) {}
+	ListmodeToSinograms() : stir::LmToProjData()
 	{
 		fan_size = -1;
 		store_prompts = true;
@@ -119,7 +119,7 @@ public:
 		std::pair<double, double> interval(start, stop);
 		std::vector < std::pair<double, double> > intervals;
 		intervals.push_back(interval);
-		frame_defs = TimeFrameDefinitions(intervals);
+		frame_defs = stir::TimeFrameDefinitions(intervals);
 		do_time_frame = true;
 	}
 	int set_flag(const char* flag, bool value)
@@ -207,8 +207,8 @@ protected:
 	int display_interval;
 	int KL_interval;
 	int save_interval;
-	shared_ptr<std::vector<Array<2, float> > > fan_sums_sptr;
-	shared_ptr<DetectorEfficiencies> det_eff_sptr;
+	shared_ptr<std::vector<stir::Array<2, float> > > fan_sums_sptr;
+	shared_ptr<stir::DetectorEfficiencies> det_eff_sptr;
 	shared_ptr<PETAcquisitionData> randoms_sptr;
 	void compute_fan_sums_(bool prompt_fansum = false);
 	int compute_singles_();
@@ -235,10 +235,10 @@ public:
 	PETAcquisitionSensitivityModel
 		(PETAcquisitionSensitivityModel& mod1, PETAcquisitionSensitivityModel& mod2)
 	{
-		norm_.reset(new ChainedBinNormalisation(mod1.data(), mod2.data()));
+		norm_.reset(new stir::ChainedBinNormalisation(mod1.data(), mod2.data()));
 	}
 
-	Succeeded set_up(const shared_ptr<ProjDataInfo>&);
+	stir::Succeeded set_up(const shared_ptr<stir::ProjDataInfo>&);
 
 	// multiply by bin efficiencies
 	virtual void unnormalise(PETAcquisitionData& ad) const;
@@ -261,15 +261,15 @@ public:
 		return sptr_ad;
 	}
 
-	shared_ptr<BinNormalisation> data()
+	shared_ptr<stir::BinNormalisation> data()
 	{
 		return norm_;
-		//return std::dynamic_pointer_cast<BinNormalisation>(norm_);
+		//return std::dynamic_pointer_cast<stir::BinNormalisation>(norm_);
 	}
 
 protected:
-	shared_ptr<BinNormalisation> norm_;
-	//shared_ptr<ChainedBinNormalisation> norm_;
+	shared_ptr<stir::BinNormalisation> norm_;
+	//shared_ptr<stir::ChainedBinNormalisation> norm_;
 };
 
 /*!
@@ -312,11 +312,11 @@ later via AcquisitionData subsets.
 
 class PETAcquisitionModel {
 public:
-	void set_projectors(shared_ptr<ProjectorByBinPair> sptr_projectors)
+	void set_projectors(shared_ptr<stir::ProjectorByBinPair> sptr_projectors)
 	{
 		sptr_projectors_ = sptr_projectors;
 	}
-	shared_ptr<ProjectorByBinPair> projectors_sptr()
+	shared_ptr<stir::ProjectorByBinPair> projectors_sptr()
 	{
 		return sptr_projectors_;
 	}
@@ -336,22 +336,22 @@ public:
 	{
 		return sptr_background_;
 	}
-	//void set_normalisation(shared_ptr<BinNormalisation> sptr)
+	//void set_normalisation(shared_ptr<stir::BinNormalisation> sptr)
 	//{
 	//	sptr_normalisation_ = sptr;
 	//}
-	shared_ptr<BinNormalisation> normalisation_sptr()
+	shared_ptr<stir::BinNormalisation> normalisation_sptr()
 	{
 		if (sptr_asm_.get())
 			return sptr_asm_->data();
-		shared_ptr<BinNormalisation> sptr;
+		shared_ptr<stir::BinNormalisation> sptr;
 		return sptr;
 		//return sptr_normalisation_;
 	}
 	//void set_bin_efficiency(shared_ptr<PETAcquisitionData> sptr_data);
 	//void set_normalisation(shared_ptr<PETAcquisitionData> sptr_data)
 	//{
-	//	sptr_normalisation_.reset(new BinNormalisationFromProjData(*sptr_data));
+	//	sptr_normalisation_.reset(new stir::BinNormalisationFromProjData(*sptr_data));
 	//}
 	void set_asm(shared_ptr<PETAcquisitionSensitivityModel> sptr_asm)
 	{
@@ -373,7 +373,7 @@ public:
 		//sptr_normalisation_.reset();
 	}
 
-	virtual Succeeded set_up(
+	virtual stir::Succeeded set_up(
 		shared_ptr<PETAcquisitionData> sptr_acq,
 		shared_ptr<PETImageData> sptr_image);
 
@@ -389,13 +389,13 @@ public:
 		int subset_num = 0, int num_subsets = 1);
 
 protected:
-	shared_ptr<ProjectorByBinPair> sptr_projectors_;
+	shared_ptr<stir::ProjectorByBinPair> sptr_projectors_;
 	shared_ptr<PETAcquisitionData> sptr_acq_template_;
 	shared_ptr<PETImageData> sptr_image_template_;
 	shared_ptr<PETAcquisitionData> sptr_add_;
 	shared_ptr<PETAcquisitionData> sptr_background_;
 	shared_ptr<PETAcquisitionSensitivityModel> sptr_asm_;
-	//shared_ptr<BinNormalisation> sptr_normalisation_;
+	//shared_ptr<stir::BinNormalisation> sptr_normalisation_;
 };
 
 /*!
@@ -418,28 +418,28 @@ class PETAcquisitionModelUsingMatrix : public PETAcquisitionModel {
 	{
 		this->sptr_projectors_.reset(new ProjectorPairUsingMatrix);
 	}
-	void set_matrix(shared_ptr<ProjMatrixByBin> sptr_matrix)
+	void set_matrix(shared_ptr<stir::ProjMatrixByBin> sptr_matrix)
 	{
 		sptr_matrix_ = sptr_matrix;
 		((ProjectorPairUsingMatrix*)this->sptr_projectors_.get())->
 			set_proj_matrix_sptr(sptr_matrix);
 	}
-	shared_ptr<ProjMatrixByBin> matrix_sptr()
+	shared_ptr<stir::ProjMatrixByBin> matrix_sptr()
 	{
 		return ((ProjectorPairUsingMatrix*)this->sptr_projectors_.get())->
 			get_proj_matrix_sptr();
 	}
-	virtual Succeeded set_up(
+	virtual stir::Succeeded set_up(
 		shared_ptr<PETAcquisitionData> sptr_acq,
 		shared_ptr<PETImageData> sptr_image)
 	{
 		if (!sptr_matrix_.get())
-			return Succeeded::no;
+			return stir::Succeeded::no;
 		return PETAcquisitionModel::set_up(sptr_acq, sptr_image);
 	}
 
 private:
-	shared_ptr<ProjMatrixByBin> sptr_matrix_;
+	shared_ptr<stir::ProjMatrixByBin> sptr_matrix_;
 };
 
 typedef PETAcquisitionModel AcqMod3DF;
@@ -460,7 +460,7 @@ public:
 	// divide by bin efficiencies
 	virtual void normalise(PETAcquisitionData& ad) const;
 protected:
-	shared_ptr<ForwardProjectorByBin> sptr_forw_projector_;
+	shared_ptr<stir::ForwardProjectorByBin> sptr_forw_projector_;
 };
 
 /*!
@@ -472,21 +472,21 @@ and hence cannot be called directly. The 'accessor' classes below bypass the
 protection by inheritance.
 */
 
-class xSTIR_GeneralisedPrior3DF : public GeneralisedPrior < Image3DF > {
+class xSTIR_GeneralisedPrior3DF : public stir::GeneralisedPrior < Image3DF > {
 public:
 	bool post_process() {
 		return post_processing();
 	}
 };
 
-class xSTIR_QuadraticPrior3DF : public QuadraticPrior < float > {
+class xSTIR_QuadraticPrior3DF : public stir::QuadraticPrior < float > {
 public:
 	void only2D(int only) {
 		only_2D = only != 0;
 	}
 };
 
-class xSTIR_PLSPrior3DF : public PLSPrior < float > {
+class xSTIR_PLSPrior3DF : public stir::PLSPrior < float > {
 public:
 	void only2D(int only) {
 		only_2D = only != 0;
@@ -494,7 +494,7 @@ public:
 };
 
 class xSTIR_GeneralisedObjectiveFunction3DF :
-	public GeneralisedObjectiveFunction<Image3DF> {
+	public stir::GeneralisedObjectiveFunction<Image3DF> {
 public:
 	bool post_process() {
 		return post_processing();
@@ -504,7 +504,7 @@ public:
 //typedef xSTIR_GeneralisedObjectiveFunction3DF ObjectiveFunction3DF;
 
 class xSTIR_PoissonLogLikelihoodWithLinearModelForMeanAndProjData3DF :
-	public PoissonLogLikelihoodWithLinearModelForMeanAndProjData<Image3DF> {
+	public stir::PoissonLogLikelihoodWithLinearModelForMeanAndProjData<Image3DF> {
 public:
 	void set_input_file(const char* filename) {
 		input_filename = filename;
@@ -537,14 +537,14 @@ typedef xSTIR_PoissonLogLikelihoodWithLinearModelForMeanAndProjData3DF
 PoissonLogLhLinModMeanProjData3DF;
 
 class xSTIR_IterativeReconstruction3DF :
-	public IterativeReconstruction<Image3DF> {
+	public stir::IterativeReconstruction<Image3DF> {
 public:
 	bool post_process() {
 		if (this->output_filename_prefix.length() < 1)
 			this->set_output_filename_prefix("reconstructed_image");
 		return post_processing();
 	}
-	Succeeded setup(sptrImage3DF const& image) {
+	stir::Succeeded setup(sptrImage3DF const& image) {
 		return set_up(image);
 	}
 	void update(Image3DF &image) {
@@ -564,11 +564,11 @@ public:
 };
 
 class xSTIR_OSMAPOSLReconstruction3DF : 
-	public OSMAPOSLReconstruction < Image3DF > {
+	public stir::OSMAPOSLReconstruction < Image3DF > {
 public:
-	Succeeded set_up(shared_ptr<PETImageData> sptr_id)
+	stir::Succeeded set_up(shared_ptr<PETImageData> sptr_id)
 	{
-		Succeeded s = Succeeded::no;
+		stir::Succeeded s = stir::Succeeded::no;
 		xSTIR_IterativeReconstruction3DF* ptr_r =
 			(xSTIR_IterativeReconstruction3DF*)this;
 		if (!ptr_r->post_process()) {
@@ -589,14 +589,14 @@ public:
 
 typedef xSTIR_OSMAPOSLReconstruction3DF OSMAPOSLReconstruction3DF;
 
-class xSTIR_OSSPSReconstruction3DF : public OSSPSReconstruction < Image3DF > {
+class xSTIR_OSSPSReconstruction3DF : public stir::OSSPSReconstruction < Image3DF > {
 public:
 	float& relaxation_parameter_value() {
 		return relaxation_parameter;
 	}
 };
 
-class xSTIR_FBP2DReconstruction : public FBP2DReconstruction {
+class xSTIR_FBP2DReconstruction : public stir::FBP2DReconstruction {
 public:
 	xSTIR_FBP2DReconstruction()
 	{
@@ -630,13 +630,13 @@ public:
 			("wrong frequency cut-off", __FILE__, __LINE__);
 		fc_ramp = fc;
 	}
-	Succeeded set_up(shared_ptr<PETImageData> sptr_id)
+	stir::Succeeded set_up(shared_ptr<PETImageData> sptr_id)
 	{
 		_sptr_image_data.reset(new PETImageData(*sptr_id));
 		_is_set_up = true;
-		return Succeeded::yes;
+		return stir::Succeeded::yes;
 	}
-	Succeeded process()
+	stir::Succeeded process()
 	{
 		if (!_is_set_up) {
 			shared_ptr<Image3DF> sptr_image(construct_target_image_ptr());


### PR DESCRIPTION
Closes #195 

Inclusion of cstir and cgadgetron files resulted in ambiguous use of shared_ptr due to 
using namespace statements in header files.

Replaced >using stir::shared_ptr; by >using namespace stir; in .cpp files. 
These .cpp are not included anywhere, so no importing of STIR object into the global namespace happens.