### PR TITLE
Add weighted average for SIRFRegImageDeformation class

### DIFF
--- a/src/Registration/cReg/SIRFRegImageWeightedMean.cpp
+++ b/src/Registration/cReg/SIRFRegImageWeightedMean.cpp
@@ -112,8 +112,8 @@ void SIRFRegImageWeightedMean::check_can_do_mean() const
 
     // Print all the info
     std::cout << "\n\nChecking that images can be combined...\n\n";
-    std::cout << "im || datatype | ndim | nvox     | nx  | ny  | nz | dx      | dy      | dz  \n";
-    std::cout << "---++----------+------+----------+-----+-----+----+---------+---------+------\n";
+    std::cout << "im || datatype | ndim | nvox | nx  | ny  | nz | nt | nu | dx | dy | dz | dt | du \n";
+    std::cout << "---++----------+------+------+-----+-----+----+----+----+----+----+----+----+----\n";
     for (unsigned i=0; i<_input_images.size(); i++) {
         std::cout << i << "  || ";
         std::string data_type = nifti_datatype_string(_input_images[i].get_image_as_nifti()->datatype);
@@ -123,9 +123,13 @@ void SIRFRegImageWeightedMean::check_can_do_mean() const
         std::cout << _input_images[i].get_image_as_nifti()->nx   <<    " | ";
         std::cout << _input_images[i].get_image_as_nifti()->ny   <<    " | ";
         std::cout << _input_images[i].get_image_as_nifti()->nz   <<    " | ";
+        std::cout << _input_images[i].get_image_as_nifti()->nt   <<    " | ";
+        std::cout << _input_images[i].get_image_as_nifti()->nu   <<    " | ";
         std::cout << _input_images[i].get_image_as_nifti()->dx   <<    " | ";
         std::cout << _input_images[i].get_image_as_nifti()->dy   <<    " | ";
-        std::cout << _input_images[i].get_image_as_nifti()->dz   << "\n";
+        std::cout << _input_images[i].get_image_as_nifti()->dz   <<    " | ";
+        std::cout << _input_images[i].get_image_as_nifti()->dt   <<    " | ";
+        std::cout << _input_images[i].get_image_as_nifti()->du   <<    "\n";
     }
     bool can_do_mean = true;
 

--- a/src/Registration/cReg/SIRFRegImageWeightedMean.h
+++ b/src/Registration/cReg/SIRFRegImageWeightedMean.h
@@ -34,6 +34,7 @@ limitations under the License.
 #include <string>
 #include <vector>
 #include "SIRFImageData.h"
+#include "SIRFImageDataDeformation.h"
 
 /// Calculate the weighted mean of a set of images
 class SIRFRegImageWeightedMean
@@ -68,12 +69,32 @@ protected:
 
     /// Bool to check if update is necessary
     bool                        _need_to_update;
-    /// Vector of input images
-    std::vector<SIRFImageData>  _input_images;
     /// Vector of weights
     std::vector<float>          _weights;
+    
+
+private:
+    /// Vector of input images
+    std::vector<SIRFImageData>  _input_images;
     /// Output image
     SIRFImageData               _output_image;
+
+};
+
+
+class SIRFRegImageDeformationWeightedMean : public SIRFRegImageWeightedMean
+{
+
+public:
+    /// Get output
+    const SIRFImageDataDeformation &get_output() const { return _output_image; }
+
+private:
+
+    /// Vector of input images
+    std::vector<SIRFImageDataDeformation>  _input_images;
+    /// Output image
+    SIRFImageDataDeformation               _output_image;
 
 };
 


### PR DESCRIPTION
New class `SIRFRegImageDeformationWeightedMean`.
Allows for weighted mean of type `SIRFImageDataDeformation`.
`SIRFRegImageDeformationWeightedMean` inherits from `SIRFRegImageWeightedMean`.

To use the existing methods, the members in the base class  `SIRFRegImageWeightedMean` were declared private to avoid being passed to the child class.
Keeping the member names of the child the same but changing the tpe allows to use base class methods without the need to redefine them.

Also adjusted std::cout output of  check function if averaging the data is justified to include the displacement field dimensions.
