### PR TITLE
Fixed compiling errors due 

### DIFF
--- a/src/Registration/cReg/SIRFImageData.h
+++ b/src/Registration/cReg/SIRFImageData.h
@@ -32,6 +32,7 @@ limitations under the License.
 
 #include <nifti1_io.h>
 #include <string>
+#include <memory>
 
 template <int num_dimensions>
 class VoxelisedGeometricalInfo;

--- a/src/Registration/cReg/SIRFRegImageWeightedMean.h
+++ b/src/Registration/cReg/SIRFRegImageWeightedMean.h
@@ -71,7 +71,7 @@ protected:
     /// Bool to check if update is necessary
     bool                      _need_to_update;
     /// Vector of input images
-    std::vector<const ImType> _input_images;
+    std::vector<ImType> _input_images;
     /// Vector of weights
     std::vector<float>        _weights;
     /// Output image


### PR DESCRIPTION
@rijobro 
The two compiling errors occured due to:

1. Missing `#include<memory>` led to error using `std::shared_ptr` in `SIRFImageData` class.
2. In `SIRFRegImageWeightedMean` an   `std::vector< const ImType>`  template argument led to compilation errors.

