### PR TITLE
Update coil_combination.py so that no PEP8 warnings are issued by Spyder

### DIFF
--- a/examples/Python/MR/interactive/coil_combination.py
+++ b/examples/Python/MR/interactive/coil_combination.py
@@ -13,24 +13,24 @@
 # Author: Christoph Kolbitsch
 #
 
-## CCP PETMR Synergistic Image Reconstruction Framework (SIRF).
-## Copyright 2015 - 2017 Rutherford Appleton Laboratory STFC.
-## Copyright 2015 - 2017 University College London.
-## Copyright 2015 - 2017 Physikalisch-Technische Bundesanstalt.
-##
-## This is software developed for the Collaborative Computational
-## Project in Positron Emission Tomography and Magnetic Resonance imaging
-## (http://www.ccppetmr.ac.uk/).
-##
-## Licensed under the Apache License, Version 2.0 (the "License");
-##   you may not use this file except in compliance with the License.
-##   You may obtain a copy of the License at
-##       http://www.apache.org/licenses/LICENSE-2.0
-##   Unless required by applicable law or agreed to in writing, software
-##   distributed under the License is distributed on an "AS IS" BASIS,
-##   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-##   See the License for the specific language governing permissions and
-##   limitations under the License.
+# # CCP PETMR Synergistic Image Reconstruction Framework (SIRF).
+# # Copyright 2015 - 2017 Rutherford Appleton Laboratory STFC.
+# # Copyright 2015 - 2017 University College London.
+# # Copyright 2015 - 2017 Physikalisch-Technische Bundesanstalt.
+# #
+# # This is software developed for the Collaborative Computational
+# # Project in Positron Emission Tomography and Magnetic Resonance imaging
+# # (http://www.ccppetmr.ac.uk/).
+# #
+# # Licensed under the Apache License, Version 2.0 (the "License");
+# #   you may not use this file except in compliance with the License.
+# #   You may obtain a copy of the License at
+# #       http://www.apache.org/licenses/LICENSE-2.0
+# #   Unless required by applicable law or agreed to in writing, software
+# #   distributed under the License is distributed on an "AS IS" BASIS,
+# #   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# #   See the License for the specific language governing permissions and
+# #   limitations under the License.
 
 __version__ = '0.1.0'
 
@@ -38,110 +38,112 @@ __version__ = '0.1.0'
 import pGadgetron as pMR
 
 # import further modules
-import os, numpy
+import os
+import numpy
 import matplotlib.pyplot as plt
 
-#%% GO TO MR FOLDER
+# %% GO TO MR FOLDER
 os.chdir(pMR.petmr_data_path('mr'))
 
-#%% LOAD AND PREPROCESS RAW MR DATA
+# %% LOAD AND PREPROCESS RAW MR DATA
 acq_data = pMR.AcquisitionData('simulated_MR_2D_cartesian.h5')
 preprocessed_data = pMR.preprocess_acquisition_data(acq_data)
 
 
-#%% CHECK IF K-SPACE DATA IS SORTED
+# %% CHECK IF K-SPACE DATA IS SORTED
 print('Is k-space data sorted? %s' % preprocessed_data.is_sorted())
 
 
-#%% SORT K-SPACE DATA
+# %% SORT K-SPACE DATA
 preprocessed_data.sort()
 print('Is k-space data sorted? %s' % preprocessed_data.is_sorted())
 
 
-#%% RETRIEVE K-SPACE DATA
+# %% RETRIEVE K-SPACE DATA
 k_array = preprocessed_data.as_array()
 print('Size of k-space %dx%dx%d' % k_array.shape)
 
 
-#%% SELECT FIRST REPETITION AND VIEW DATA
-k_array = k_array[0:256,:,:]
+# %% SELECT FIRST REPETITION AND VIEW DATA
+k_array = k_array[0:256, :, :]
 print('Size of k-space %dx%dx%d' % k_array.shape)
 
 plt.close()
 fig = plt.figure(1)
 plt.set_cmap('jet')
 for c in range(k_array.shape[1]):
-    ax = fig.add_subplot(2,4,c+1)
-    ax.imshow(abs(k_array[:,c,:]), vmin=0, vmax=1)
+    ax = fig.add_subplot(2, 4, c+1)
+    ax.imshow(abs(k_array[:, c, :]), vmin=0, vmax=1)
     ax.set_title('Coil '+str(c+1))
     ax.axis('off')
 
 
-#%% APPLY INVERSE FFT TO EACH COIL AND VIEW IMAGES
+# %% APPLY INVERSE FFT TO EACH COIL AND VIEW IMAGES
 image_array = numpy.zeros(k_array.shape, numpy.complex128)
 for c in range(k_array.shape[1]):
-    image_array[:,c,:] = numpy.fft.fftshift(numpy.fft.ifft2(numpy.fft.ifftshift(k_array[:,c,:])))
+    image_array[:, c, :] = numpy.fft.fftshift(
+            numpy.fft.ifft2(numpy.fft.ifftshift(k_array[:, c, :])))
 image_array /= abs(image_array).max()
-   
-fig = plt.figure(2)   
+
+fig = plt.figure(2)
 plt.set_cmap('gray')
 for c in range(image_array.shape[1]):
-    ax = fig.add_subplot(2,4,c+1)
-    ax.imshow(abs(image_array[:,c,:]), vmin=0, vmax=0.4)
+    ax = fig.add_subplot(2, 4, c+1)
+    ax.imshow(abs(image_array[:, c, :]), vmin=0, vmax=0.4)
     ax.set_title('Coil '+str(c+1))
     ax.axis('off')
-    
-    
-#%% COMBINE COIL IMAGES USING SOS
-image_array_sos = abs(numpy.sqrt(numpy.sum(numpy.square(image_array),1)))    
+
+
+# %% COMBINE COIL IMAGES USING SOS
+image_array_sos = abs(numpy.sqrt(numpy.sum(numpy.square(image_array), 1)))
 image_array_sos = image_array_sos/image_array_sos.max()
 
 fig = plt.figure(3)
 plt.set_cmap('gray')
 plt.imshow(image_array_sos, vmin=0, vmax=0.7)
-plt.title('Combined image using sum-of-squares') 
+plt.title('Combined image using sum-of-squares')
 
 
-#%% CALCULATE COIL SENSITIVITIES
+# %% CALCULATE COIL SENSITIVITIES
 csm = pMR.CoilSensitivityData()
 csm.smoothness = 4
 csm.calculate(preprocessed_data)
 csm_array = numpy.squeeze(csm.as_array(0))
 
 # csm_array has orientation [coil, im_x, im_y]
-csm_array = csm_array.transpose([1,0,2])
+csm_array = csm_array.transpose([1, 0, 2])
 
 fig = plt.figure(4)
 plt.set_cmap('jet')
 for c in range(csm_array.shape[1]):
-    ax = fig.add_subplot(2,4,c+1)
-    ax.imshow(abs(csm_array[:,c,:]))
+    ax = fig.add_subplot(2, 4, c+1)
+    ax.imshow(abs(csm_array[:, c, :]))
     ax.set_title('Coil '+str(c+1))
     ax.axis('off')
 
 
-#%% COMBINE COIL IMAGES USING WEIGHTED SUM
-image_array_ws = numpy.sum(numpy.multiply(image_array, numpy.conj(csm_array)),1)
-image_array_ws = abs(numpy.divide(image_array_ws, numpy.sum(numpy.multiply(csm_array, numpy.conj(csm_array)),1)))
+# %% COMBINE COIL IMAGES USING WEIGHTED SUM
+image_array_ws = numpy.sum(numpy.multiply(image_array,
+                                          numpy.conj(csm_array)), 1)
+image_array_ws = abs(numpy.divide(
+        image_array_ws,
+        numpy.sum(numpy.multiply(csm_array, numpy.conj(csm_array)), 1)))
 image_array_ws = image_array_ws/image_array_ws.max()
 
 fig = plt.figure(5, figsize=[12, 4])
 plt.set_cmap('gray')
 
-ax = fig.add_subplot(1,3,1)
+ax = fig.add_subplot(1, 3, 1)
 ax.imshow(image_array_sos, vmin=0, vmax=0.7)
 ax.set_title('Sum-of-squares (SOS)')
 ax.axis('off')
 
-ax = fig.add_subplot(1,3,2)
+ax = fig.add_subplot(1, 3, 2)
 ax.imshow(image_array_ws, vmin=0, vmax=0.7)
 ax.set_title('Weighted sum (WS)')
 ax.axis('off')
 
-ax = fig.add_subplot(1,3,3)
+ax = fig.add_subplot(1, 3, 3)
 ax.imshow(abs(image_array_sos-image_array_ws), vmin=0, vmax=0.1)
 ax.set_title('SOS - WS')
 ax.axis('off')
-
-
-

--- a/examples/Python/MR/interactive/coil_combination.py
+++ b/examples/Python/MR/interactive/coil_combination.py
@@ -13,24 +13,24 @@
 # Author: Christoph Kolbitsch
 #
 
-# # CCP PETMR Synergistic Image Reconstruction Framework (SIRF).
-# # Copyright 2015 - 2017 Rutherford Appleton Laboratory STFC.
-# # Copyright 2015 - 2017 University College London.
-# # Copyright 2015 - 2017 Physikalisch-Technische Bundesanstalt.
-# #
-# # This is software developed for the Collaborative Computational
-# # Project in Positron Emission Tomography and Magnetic Resonance imaging
-# # (http://www.ccppetmr.ac.uk/).
-# #
-# # Licensed under the Apache License, Version 2.0 (the "License");
-# #   you may not use this file except in compliance with the License.
-# #   You may obtain a copy of the License at
-# #       http://www.apache.org/licenses/LICENSE-2.0
-# #   Unless required by applicable law or agreed to in writing, software
-# #   distributed under the License is distributed on an "AS IS" BASIS,
-# #   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# #   See the License for the specific language governing permissions and
-# #   limitations under the License.
+# CCP PETMR Synergistic Image Reconstruction Framework (SIRF).
+# Copyright 2015 - 2017 Rutherford Appleton Laboratory STFC.
+# Copyright 2015 - 2017 University College London.
+# Copyright 2015 - 2017 Physikalisch-Technische Bundesanstalt.
+#
+# This is software developed for the Collaborative Computational
+# Project in Positron Emission Tomography and Magnetic Resonance imaging
+# (http://www.ccppetmr.ac.uk/).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#       http://www.apache.org/licenses/LICENSE-2.0
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
 
 __version__ = '0.1.0'
 


### PR DESCRIPTION
I changed this file so that Spyder would not issue any PEP8 warnings. This is in response to @ckolbPTB who was asking about these:

> Which lines do not follow PEP8? We tried to follow the standard but maybe we missed a few things...

According to Spyder, PEP8 
- requires white spaces after comma

and does not allow 

- empty lines at end of file
- lines with more than 79 chars
- trailing white spaces
- non-white space symbols after "#"

Whether or not to integrate these changes / style in SIRF is a different matter.