### PR TITLE
[FIX] Build error with gcc 7.3.0

### DIFF
--- a/src/Registration/cReg/NiftiImageData.h
+++ b/src/Registration/cReg/NiftiImageData.h
@@ -31,6 +31,7 @@ limitations under the License.
 #define _NIFTIIMAGEDATA_H_
 
 #include <nifti1_io.h>
+#include <vector>
 #include <string>
 #include <memory>
 #include <iostream>


### PR DESCRIPTION
Just a small one. I guess I am using a newer c++ standard? But build with this.