### PR TITLE
[FIX] Constructing STIR Image from Acq Data with nx, ny should use Acq data

### DIFF
--- a/src/xSTIR/cSTIR/cstir.cpp
+++ b/src/xSTIR/cSTIR/cstir.cpp
@@ -907,24 +907,8 @@ void* cSTIR_imageFromAcquisitionDataAndNxNy(void* ptr_ad, int nx, int ny)
 	try {
 		shared_ptr<PETAcquisitionData>& sptr_ad =
 			objectSptrFromHandle<PETAcquisitionData>(ptr_ad);
-		PETImageData id(*sptr_ad);
-		int dim[3];
-		float vs[3];
-		float is[3];
-		id.get_dimensions(dim);
-		id.get_voxel_sizes(vs);
-		for (int i = 0; i < 3; i++)
-			is[i] = dim[i] * vs[i];
-		int nz = dim[0];
-		float vx = is[2] / nx;
-		float vy = is[1] / ny;
-		float vz = vs[0];
-		shared_ptr<Voxels3DF> sptr_v(new Voxels3DF(IndexRange3D(0, nz - 1,
-			-(ny / 2), -(ny / 2) + ny - 1, -(nx / 2), -(nx / 2) + nx - 1),
-			Coord3DF(0, 0, 0),
-			Coord3DF(vz, vy, vx)));
-		shared_ptr<PETImageData> sptr(new PETImageData(*sptr_v));
-		sptr->fill(0.0);
+		shared_ptr<PETImageData> sptr(
+			new PETImageData(*sptr_ad, nx, ny));
 		return newObjectHandle(sptr);
 	}
 	CATCH;

--- a/src/xSTIR/cSTIR/stir_data_containers.h
+++ b/src/xSTIR/cSTIR/stir_data_containers.h
@@ -476,6 +476,16 @@ namespace sirf {
 		{
 			_data.reset(new Voxels3DF(*ad.get_proj_data_info_sptr()));
 		}
+		PETImageData
+		(const PETAcquisitionData& ad, const int nx, const int ny, const float zoom=1.)
+		{
+			const Coord3DF origin(0, 0, 0);
+			const Coord3DI sizes(-1, ny, nx);
+			_data.reset(
+				new Voxels3DF(
+					*ad.get_proj_data_info_sptr(),
+					zoom, origin, sizes));
+		}
 		PETImageData(const Image3DF& image)
 		{
 			_data.reset(image.clone());


### PR DESCRIPTION
Previously, if nx, ny was specified, then the resulting VoxelsOnCartGrid didn't actually use the constructor with AcqData