### PR TITLE
Aquisition reader

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 * created namespace `sirf`
 * added default constructor and set_up to MRAcquisitionModel
 * implemented sorting of MR images
+* implemented reading of MR acquisition data from ISMRMRD file
 
 ## v1.1.0
 

--- a/src/xGadgetron/cGadgetron/gadgetron_data_containers.cpp
+++ b/src/xGadgetron/cGadgetron/gadgetron_data_containers.cpp
@@ -67,33 +67,41 @@ MRAcquisitionData::read( const std::string& filename_ismrmrd_with_ext )
 
 	if( verbose )
 		std::cout<< "Started reading acquisitions from " << filename_ismrmrd_with_ext << std::endl;
-
-
-	ISMRMRD::Dataset d(filename_ismrmrd_with_ext.c_str(),"dataset", false);
-
-	std::string xml;
-	d.readHeader(xml);
-	this->acqs_info_ = xml;
-
-	uint32_t num_acquis = d.getNumberOfAcquisitions();
-	for( uint32_t i_acqu=0; i_acqu<num_acquis; i_acqu++)
+	try
 	{
-		if( verbose )
+
+		ISMRMRD::Dataset d(filename_ismrmrd_with_ext.c_str(),"dataset", false);
+
+		std::string xml;
+		d.readHeader(xml);
+		this->acqs_info_ = xml;
+
+		uint32_t num_acquis = d.getNumberOfAcquisitions();
+		for( uint32_t i_acqu=0; i_acqu<num_acquis; i_acqu++)
 		{
-			if( i_acqu%( num_acquis/10 ) == 0 )
-				std::cout << float(i_acqu)/num_acquis*100.f << " % " << std::endl;
+			if( verbose )
+			{
+				if( i_acqu%( num_acquis/10 ) == 0 )
+					std::cout << float(i_acqu)/num_acquis*100.f << " % " << std::endl;
+			}
+
+			ISMRMRD::Acquisition acq;
+			d.readAcquisition( i_acqu, acq);
+
+			if( TO_BE_IGNORED(acq) )
+				continue;
+			
+			this->append_acquisition( acq );
 		}
-
-		ISMRMRD::Acquisition acq;
-		d.readAcquisition( i_acqu, acq);
-
-		if( TO_BE_IGNORED(acq) )
-			continue;
-		
-		this->append_acquisition( acq );
+		if( verbose )
+			std::cout<< "Finished reading acquisitions from " << filename_ismrmrd_with_ext << std::endl;
 	}
-	if( verbose )
-		std::cout<< "Finished reading acquisitions from " << filename_ismrmrd_with_ext << std::endl;
+	catch( std::runtime_error& e)
+	{
+		std::cout << "An exception was caught reading " << filename_ismrmrd_with_ext << std::endl;
+		std::cout << e.what() <<std::endl;
+		throw;
+	}
 }
 
 bool

--- a/src/xGadgetron/cGadgetron/gadgetron_data_containers.cpp
+++ b/src/xGadgetron/cGadgetron/gadgetron_data_containers.cpp
@@ -59,6 +59,12 @@ MRAcquisitionData::write(const char* filename)
 	}
 }
 
+void
+MRAcquisitionData::read( void )
+{
+	
+}
+
 bool
 MRAcquisitionData::undersampled() const
 {

--- a/src/xGadgetron/cGadgetron/gadgetron_data_containers.cpp
+++ b/src/xGadgetron/cGadgetron/gadgetron_data_containers.cpp
@@ -73,9 +73,7 @@ MRAcquisitionData::read( const std::string& filename_ismrmrd_with_ext )
 
 		ISMRMRD::Dataset d(filename_ismrmrd_with_ext.c_str(),"dataset", false);
 
-		std::string xml;
-		d.readHeader(xml);
-		this->acqs_info_ = xml;
+		d.readHeader(this->acqs_info_);
 
 		uint32_t num_acquis = d.getNumberOfAcquisitions();
 		for( uint32_t i_acqu=0; i_acqu<num_acquis; i_acqu++)

--- a/src/xGadgetron/cGadgetron/gadgetron_data_containers.cpp
+++ b/src/xGadgetron/cGadgetron/gadgetron_data_containers.cpp
@@ -60,9 +60,40 @@ MRAcquisitionData::write(const char* filename)
 }
 
 void
-MRAcquisitionData::read( void )
+MRAcquisitionData::read( const std::string& filename_ismrmrd_with_ext )
 {
 	
+	bool const verbose = true;
+
+	if( verbose )
+		std::cout<< "Started reading acquisitions from " << filename_ismrmrd_with_ext << std::endl;
+
+
+	ISMRMRD::Dataset d(filename_ismrmrd_with_ext.c_str(),"dataset", false);
+
+	std::string xml;
+	d.readHeader(xml);
+	this->acqs_info_ = xml;
+
+	uint32_t num_acquis = d.getNumberOfAcquisitions();
+	for( uint32_t i_acqu=0; i_acqu<num_acquis; i_acqu++)
+	{
+		if( verbose )
+		{
+			if( i_acqu%( num_acquis/10 ) == 0 )
+				std::cout << float(i_acqu)/num_acquis*100.f << " % " << std::endl;
+		}
+
+		ISMRMRD::Acquisition acq;
+		d.readAcquisition( i_acqu, acq);
+
+		if( TO_BE_IGNORED(acq) )
+			continue;
+		
+		this->append_acquisition( acq );
+	}
+	if( verbose )
+		std::cout<< "Finished reading acquisitions from " << filename_ismrmrd_with_ext << std::endl;
 }
 
 bool

--- a/src/xGadgetron/cGadgetron/gadgetron_data_containers.cpp
+++ b/src/xGadgetron/cGadgetron/gadgetron_data_containers.cpp
@@ -99,8 +99,8 @@ MRAcquisitionData::read( const std::string& filename_ismrmrd_with_ext )
 	}
 	catch( std::runtime_error& e)
 	{
-		std::cout << "An exception was caught reading " << filename_ismrmrd_with_ext << std::endl;
-		std::cout << e.what() <<std::endl;
+		std::cerr << "An exception was caught reading " << filename_ismrmrd_with_ext << std::endl;
+		std::cerr << e.what() <<std::endl;
 		throw;
 	}
 }

--- a/src/xGadgetron/cGadgetron/gadgetron_data_containers.cpp
+++ b/src/xGadgetron/cGadgetron/gadgetron_data_containers.cpp
@@ -26,6 +26,7 @@ limitations under the License.
 \author Evgueni Ovtchinnikov
 \author CCP PETMR
 */
+#include <cmath>
 
 #include "cgadgetron_shared_ptr.h"
 #include "gadgetron_data_containers.h"
@@ -82,7 +83,7 @@ MRAcquisitionData::read( const std::string& filename_ismrmrd_with_ext )
 			if( verbose )
 			{
 				if( i_acqu%( num_acquis/10 ) == 0 )
-					std::cout << float(i_acqu)/num_acquis*100.f << " % " << std::endl;
+					std::cout << std::ceil( float(i_acqu)/num_acquis*100 )<< " % " << " done."<< std::endl;
 			}
 
 			ISMRMRD::Acquisition acq;
@@ -90,8 +91,8 @@ MRAcquisitionData::read( const std::string& filename_ismrmrd_with_ext )
 
 			if( TO_BE_IGNORED(acq) )
 				continue;
-			
-			this->append_acquisition( acq );
+			else
+				this->append_acquisition( acq );
 		}
 		if( verbose )
 			std::cout<< "Finished reading acquisitions from " << filename_ismrmrd_with_ext << std::endl;

--- a/src/xGadgetron/cGadgetron/gadgetron_data_containers.h
+++ b/src/xGadgetron/cGadgetron/gadgetron_data_containers.h
@@ -187,7 +187,7 @@ namespace sirf {
 				return i;
 		}
 
-		void read( void );
+		void read( const std::string& filename_ismrmrd_with_ext );
 		void write(const char* filename);
 
 	protected:

--- a/src/xGadgetron/cGadgetron/gadgetron_data_containers.h
+++ b/src/xGadgetron/cGadgetron/gadgetron_data_containers.h
@@ -188,6 +188,15 @@ namespace sirf {
 				return i;
 		}
 
+    	/*! 
+    		\brief Reader for ISMRMRD::Acquisition from ISMRMRD file. 
+      		*	filename_ismrmrd_with_ext:	filename of ISMRMRD rawdata file with .h5 extension.
+      		* 
+      		* In case the ISMRMRD::Dataset constructor throws an std::runtime_error the reader catches it, 
+      		* displays the message and throws it again.
+			* To avoid reading noise samples and other calibration data, the TO_BE_IGNORED macro is employed
+			* to exclude potentially incompatible input. 
+    	*/
 		void read( const std::string& filename_ismrmrd_with_ext );
 		void write(const char* filename);
 

--- a/src/xGadgetron/cGadgetron/gadgetron_data_containers.h
+++ b/src/xGadgetron/cGadgetron/gadgetron_data_containers.h
@@ -54,6 +54,7 @@ Some acquisitions do not participate directly in the reconstruction process
 	(!(acq).isFlagSet(ISMRMRD::ISMRMRD_ACQ_IS_PARALLEL_CALIBRATION) && \
 	!(acq).isFlagSet(ISMRMRD::ISMRMRD_ACQ_IS_PARALLEL_CALIBRATION_AND_IMAGING) && \
 	!(acq).isFlagSet(ISMRMRD::ISMRMRD_ACQ_LAST_IN_MEASUREMENT) && \
+	!(acq).isFlagSet(ISMRMRD::ISMRMRD_ACQ_IS_REVERSE) && \
 	(acq).flags() >= (1 << (ISMRMRD::ISMRMRD_ACQ_IS_NOISE_MEASUREMENT - 1)))
 
 /*!

--- a/src/xGadgetron/cGadgetron/gadgetron_data_containers.h
+++ b/src/xGadgetron/cGadgetron/gadgetron_data_containers.h
@@ -187,6 +187,7 @@ namespace sirf {
 				return i;
 		}
 
+		void read( void );
 		void write(const char* filename);
 
 	protected:


### PR DESCRIPTION
Added `MRAcquisitionsData::read( const string& )` functionality.
This enables to fill acquisition data containers with `ISMRMRD::Acquisition` from an `ISMRMRD.h5` file.

In case the `ISMRMRD::Dataset` constructor throws an `std::runtime_error` the reader catches it, displays the message and throws it again.

To avoid reading noise samples and other calibration data, the `TO_BE_IGNORED` macro previously defined is now employed to exclude the potentially incompatible input. The macro was extended to allow acquisitions flagged with `ISMRMRD::ISMRMRD_ACQ_IS_REVERSE`, i.e. ones with a reversed data readout.

The beginning and ending of file reading is displayed and the progress is displayed in steps of 10% to avoid the impression the program being stuck if the file is large. The scopes where `verbose == true` can be readily deleted without impairing the functionality if this console output is deemed unnecessary.
