### PR TITLE
Fixes #243 

### DIFF
--- a/src/xGadgetron/cGadgetron/gadgetron_data_containers.cpp
+++ b/src/xGadgetron/cGadgetron/gadgetron_data_containers.cpp
@@ -46,8 +46,8 @@ MRAcquisitionData::write(const char* filename)
 	dataset->writeHeader(acqs_info_);
 	mtx.unlock();
 	int n = number();
-	ISMRMRD::Acquisition a;
 	for (int i = 0; i < n; i++) {
+		ISMRMRD::Acquisition a;
 		get_acquisition(i, a);
 		//std::cout << i << ' ' << a.idx().repetition << '\n';
 		//if (TO_BE_IGNORED(a)) {

--- a/src/xGadgetron/cGadgetron/gadgetron_data_containers.h
+++ b/src/xGadgetron/cGadgetron/gadgetron_data_containers.h
@@ -139,8 +139,8 @@ namespace sirf {
 		virtual void set_acquisition(unsigned int num, ISMRMRD::Acquisition& acq) = 0;
 		virtual void append_acquisition(ISMRMRD::Acquisition& acq) = 0;
 
-		virtual void append_sptr_acquisition( gadgetron::shared_ptr<ISMRMRD::Acquisition> sptr_acqu)=0;
-		virtual gadgetron::shared_ptr<ISMRMRD::Acquisition> get_sptr_acquisition(unsigned int num)=0;
+		virtual void append_acquisition_sptr( gadgetron::shared_ptr<ISMRMRD::Acquisition> sptr_acqu)=0;
+		virtual gadgetron::shared_ptr<ISMRMRD::Acquisition> get_acquisition_sptr(unsigned int num)=0;
 
 
 		virtual void copy_acquisitions_info(const MRAcquisitionData& ac) = 0;
@@ -261,8 +261,8 @@ namespace sirf {
 		}
 		virtual void append_acquisition(ISMRMRD::Acquisition& acq);
 
-		virtual void append_sptr_acquisition( gadgetron::shared_ptr<ISMRMRD::Acquisition> sptr_acqu){throw LocalisedException("Function undefined for sirf::AcuisitionsFile.", __FILE__, __LINE__);};
-		virtual gadgetron::shared_ptr<ISMRMRD::Acquisition> get_sptr_acquisition(unsigned int num){throw LocalisedException("Function undefined for sirf::AcuisitionsFile.", __FILE__, __LINE__);};
+		virtual void append_acquisition_sptr( gadgetron::shared_ptr<ISMRMRD::Acquisition> sptr_acqu){throw LocalisedException("Function undefined for sirf::AcuisitionsFile.", __FILE__, __LINE__);};
+		virtual gadgetron::shared_ptr<ISMRMRD::Acquisition> get_acquisition_sptr(unsigned int num){throw LocalisedException("Function undefined for sirf::AcuisitionsFile.", __FILE__, __LINE__);};
 
 		virtual void copy_acquisitions_info(const MRAcquisitionData& ac);
 		virtual MRAcquisitionData*
@@ -316,7 +316,7 @@ namespace sirf {
 			acqs_.push_back(gadgetron::shared_ptr<ISMRMRD::Acquisition>
 				(new ISMRMRD::Acquisition(acq)));
 		}
-		virtual void append_sptr_acquisition( gadgetron::shared_ptr<ISMRMRD::Acquisition> sptr_acqu)
+		virtual void append_acquisition_sptr( gadgetron::shared_ptr<ISMRMRD::Acquisition> sptr_acqu)
 		{
 			acqs_.push_back( sptr_acqu );
 		}
@@ -325,7 +325,7 @@ namespace sirf {
 			int ind = index(num);
 			acq = *acqs_[ind];
 		}
-		virtual gadgetron::shared_ptr<ISMRMRD::Acquisition> get_sptr_acquisition(unsigned int num)
+		virtual gadgetron::shared_ptr<ISMRMRD::Acquisition> get_acquisition_sptr(unsigned int num)
 		{
 			int ind = index(num);
 			return acqs_[ind];

--- a/src/xGadgetron/cGadgetron/gadgetron_data_containers.h
+++ b/src/xGadgetron/cGadgetron/gadgetron_data_containers.h
@@ -300,6 +300,10 @@ namespace sirf {
 			acqs_.push_back(gadgetron::shared_ptr<ISMRMRD::Acquisition>
 				(new ISMRMRD::Acquisition(acq)));
 		}
+		virtual void append_sptr_acquisition( gadgetron::shared_ptr<ISMRMRD::Acquisition> sptr_acqu)
+		{
+			acqs_.push_back( sptr_acqu );
+		}
 		virtual void get_acquisition(unsigned int num, ISMRMRD::Acquisition& acq)
 		{
 			int ind = index(num);

--- a/src/xGadgetron/cGadgetron/gadgetron_data_containers.h
+++ b/src/xGadgetron/cGadgetron/gadgetron_data_containers.h
@@ -305,6 +305,12 @@ namespace sirf {
 			int ind = index(num);
 			acq = *acqs_[ind];
 		}
+		virtual gadgetron::shared_ptr<ISMRMRD::Acquisition> get_sptr_acquisition(unsigned int num)
+		{
+			int ind = index(num);
+			return acqs_[ind];
+		}
+
 		virtual void set_acquisition(unsigned int num, ISMRMRD::Acquisition& acq)
 		{
 			int ind = index(num);

--- a/src/xGadgetron/cGadgetron/gadgetron_data_containers.h
+++ b/src/xGadgetron/cGadgetron/gadgetron_data_containers.h
@@ -140,7 +140,7 @@ namespace sirf {
 		virtual void append_acquisition(ISMRMRD::Acquisition& acq) = 0;
 
 		virtual void append_acquisition_sptr( gadgetron::shared_ptr<ISMRMRD::Acquisition> sptr_acqu)=0;
-		virtual gadgetron::shared_ptr<ISMRMRD::Acquisition> get_acquisition_sptr(unsigned int num)=0;
+		virtual gadgetron::shared_ptr<ISMRMRD::Acquisition> get_acquisition_sptr(unsigned int num) const =0;
 
 
 		virtual void copy_acquisitions_info(const MRAcquisitionData& ac) = 0;
@@ -261,8 +261,15 @@ namespace sirf {
 		}
 		virtual void append_acquisition(ISMRMRD::Acquisition& acq);
 
-		virtual void append_acquisition_sptr( gadgetron::shared_ptr<ISMRMRD::Acquisition> sptr_acqu){throw LocalisedException("Function undefined for sirf::AcuisitionsFile.", __FILE__, __LINE__);};
-		virtual gadgetron::shared_ptr<ISMRMRD::Acquisition> get_acquisition_sptr(unsigned int num){throw LocalisedException("Function undefined for sirf::AcuisitionsFile.", __FILE__, __LINE__);};
+		virtual void append_acquisition_sptr( gadgetron::shared_ptr<ISMRMRD::Acquisition> sptr_acqu)
+		{
+			throw LocalisedException("Function undefined for sirf::AcuisitionsFile.", __FILE__, __LINE__);
+		};
+
+		virtual gadgetron::shared_ptr<ISMRMRD::Acquisition> get_acquisition_sptr(unsigned int num) const
+		{
+			throw LocalisedException("Function undefined for sirf::AcuisitionsFile.", __FILE__, __LINE__);
+		};
 
 		virtual void copy_acquisitions_info(const MRAcquisitionData& ac);
 		virtual MRAcquisitionData*
@@ -325,7 +332,7 @@ namespace sirf {
 			int ind = index(num);
 			acq = *acqs_[ind];
 		}
-		virtual gadgetron::shared_ptr<ISMRMRD::Acquisition> get_acquisition_sptr(unsigned int num)
+		virtual gadgetron::shared_ptr<ISMRMRD::Acquisition> get_acquisition_sptr(unsigned int num) const
 		{
 			int ind = index(num);
 			return acqs_[ind];

--- a/src/xGadgetron/cGadgetron/gadgetron_data_containers.h
+++ b/src/xGadgetron/cGadgetron/gadgetron_data_containers.h
@@ -139,6 +139,10 @@ namespace sirf {
 		virtual void set_acquisition(unsigned int num, ISMRMRD::Acquisition& acq) = 0;
 		virtual void append_acquisition(ISMRMRD::Acquisition& acq) = 0;
 
+		virtual void append_sptr_acquisition( gadgetron::shared_ptr<ISMRMRD::Acquisition> sptr_acqu)=0;
+		virtual gadgetron::shared_ptr<ISMRMRD::Acquisition> get_sptr_acquisition(unsigned int num)=0;
+
+
 		virtual void copy_acquisitions_info(const MRAcquisitionData& ac) = 0;
 
 		// 'export' constructors: workaround for creating 'ABC' objects
@@ -256,6 +260,10 @@ namespace sirf {
 			std::cerr << "AcquisitionsFile::set_acquisition not implemented yet, sorry\n";
 		}
 		virtual void append_acquisition(ISMRMRD::Acquisition& acq);
+
+		virtual void append_sptr_acquisition( gadgetron::shared_ptr<ISMRMRD::Acquisition> sptr_acqu){throw LocalisedException("Function undefined for sirf::AcuisitionsFile.", __FILE__, __LINE__);};
+		virtual gadgetron::shared_ptr<ISMRMRD::Acquisition> get_sptr_acquisition(unsigned int num){throw LocalisedException("Function undefined for sirf::AcuisitionsFile.", __FILE__, __LINE__);};
+
 		virtual void copy_acquisitions_info(const MRAcquisitionData& ac);
 		virtual MRAcquisitionData*
 			same_acquisitions_container(AcquisitionsInfo info)

--- a/src/xGadgetron/cGadgetron/gadgetron_data_containers.h
+++ b/src/xGadgetron/cGadgetron/gadgetron_data_containers.h
@@ -42,6 +42,7 @@ limitations under the License.
 #include "gadgetron_image_wrap.h"
 #include "SIRF/common/data_container.h"
 #include "SIRF/common/multisort.h"
+#include "localised_exception.h"
 
 /*!
 \ingroup Gadgetron Data Containers
@@ -181,10 +182,17 @@ namespace sirf {
 		const int* index() const { return index_; }
 		int index(int i)
 		{
-			if (index_ && i >= 0 && i < (int)number())
-				return index_[i];
+			if(i >= 0 && i < (int)number())
+			{
+				if (index_) 
+					return index_[i];
+				else
+					return i;
+			}
 			else
-				return i;
+			{
+				throw LocalisedException("Trying to access out of range acquisition.", __FILE__, __LINE__);
+			}
 		}
 
 		void write(const char* filename);

--- a/src/xGadgetron/cGadgetron/gadgetron_data_containers.h
+++ b/src/xGadgetron/cGadgetron/gadgetron_data_containers.h
@@ -140,7 +140,7 @@ namespace sirf {
 		virtual void append_acquisition(ISMRMRD::Acquisition& acq) = 0;
 
 		virtual void append_acquisition_sptr( gadgetron::shared_ptr<ISMRMRD::Acquisition> sptr_acqu)=0;
-		virtual gadgetron::shared_ptr<ISMRMRD::Acquisition> get_acquisition_sptr(unsigned int num) const =0;
+		virtual gadgetron::shared_ptr<ISMRMRD::Acquisition> get_acquisition_sptr(unsigned int num)=0;
 
 
 		virtual void copy_acquisitions_info(const MRAcquisitionData& ac) = 0;
@@ -266,7 +266,7 @@ namespace sirf {
 			throw LocalisedException("Function undefined for sirf::AcuisitionsFile.", __FILE__, __LINE__);
 		};
 
-		virtual gadgetron::shared_ptr<ISMRMRD::Acquisition> get_acquisition_sptr(unsigned int num) const
+		virtual gadgetron::shared_ptr<ISMRMRD::Acquisition> get_acquisition_sptr(unsigned int num) 
 		{
 			throw LocalisedException("Function undefined for sirf::AcuisitionsFile.", __FILE__, __LINE__);
 		};
@@ -332,7 +332,7 @@ namespace sirf {
 			int ind = index(num);
 			acq = *acqs_[ind];
 		}
-		virtual gadgetron::shared_ptr<ISMRMRD::Acquisition> get_acquisition_sptr(unsigned int num) const
+		virtual gadgetron::shared_ptr<ISMRMRD::Acquisition> get_acquisition_sptr(unsigned int num) 
 		{
 			int ind = index(num);
 			return acqs_[ind];


### PR DESCRIPTION
Functionality added to access shared pointers stored inside the `sirf::AcquisitionsVector` is added.

Appending them using the call by value function `append_sptr_acquisition(gadgetron::shared_ptr<ISMRMRD::Acquisition> sptr_acqu)` increases the internal counts of the shared pointers. This way, shared pointers to acquisitions can be extracted from one `AcquisitionsVector`, and appended to another one, without the data stored inside the objects pointed to being duplicated, as happens when the `get_acquisition(int, ISMRMRD::Acquisition& aq)` followed by `append_acquisition( const ISMRMRD::Acquisition& aq)` is used.

Also the `MRAcquisitionData::index()` function now is save to call for indices out of range.