### PR TITLE
Include data_handle.h for ObjectHandle

### DIFF
--- a/src/common/include/sirf/common/data_container.h
+++ b/src/common/include/sirf/common/data_container.h
@@ -22,6 +22,7 @@ limitations under the License.
 #define SIRF_ABSTRACT_DATA_CONTAINER_TYPE
 
 #include <map>
+#include "data_handle.h"
 
 /*
 \ingroup Data Container


### PR DESCRIPTION
Everything compiles fine as it is. But to merge master into SIRFReg, I needed to include this to be able to find ObjectHandle. 

Looking at it, I don't understand how it compiles without either the include or a forward declaration of ObjectHandle.