### PR TITLE
include directory sirf/common in base CMakeLists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,6 +120,11 @@ endif()
 
 ENABLE_TESTING()
 
+INCLUDE_DIRECTORIES(src/common/include)
+INCLUDE_DIRECTORIES(src/iUtilities/include)
+INCLUDE_DIRECTORIES(src/xSTIR/cSTIR/include)
+INCLUDE_DIRECTORIES(src/xGadgetron/cGadgetron/include)
+
 ADD_SUBDIRECTORY(src/iUtilities)
 ADD_SUBDIRECTORY(src/xSTIR)
 ADD_SUBDIRECTORY(src/xGadgetron)

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -21,9 +21,6 @@ set(CMAKE_POSITION_INDEPENDENT_CODE True)
 
 set(cSIRF_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
 
-include_directories(${PROJECT_SOURCE_DIR}/src/common/include)
-include_directories(${PROJECT_SOURCE_DIR}/src/iUtilities/include)
-
 add_library(csirf csirf.cpp)
 target_include_directories(csirf PUBLIC
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>$<INSTALL_INTERFACE:include>"

--- a/src/iUtilities/gmi/CMakeLists.txt
+++ b/src/iUtilities/gmi/CMakeLists.txt
@@ -22,7 +22,6 @@ if(BUILD_MATLAB)
 
   include_directories(${Matlab_INCLUDE_DIRS})
 
-  include_directories(${PROJECT_SOURCE_DIR}/src/common/include)
   add_executable(gmi_iutilities gmi.cpp)
   target_link_libraries(gmi_iutilities mig)
   INSTALL(TARGETS gmi_iutilities DESTINATION bin)

--- a/src/xGadgetron/CMakeLists.txt
+++ b/src/xGadgetron/CMakeLists.txt
@@ -44,8 +44,6 @@ endif()
   # need to add this as ISMRMRD_LIBRARIES doesn't set the path to the library
   link_directories("${ISMRMRD_LIBRARY_DIRS}")
 
-  include_directories(${PROJECT_SOURCE_DIR}/src/common/include)
-
   ADD_SUBDIRECTORY(cGadgetron)
 
   set(cGadgetron_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/cGadgetron")

--- a/src/xGadgetron/cGadgetron/CMakeLists.txt
+++ b/src/xGadgetron/cGadgetron/CMakeLists.txt
@@ -32,10 +32,6 @@ if (SIRF_INSTALL_DEPENDENCIES AND WIN32)
 	endforeach()
   endif()
 	
-include_directories(${PROJECT_SOURCE_DIR}/src/common/include)
-include_directories(${PROJECT_SOURCE_DIR}/src/iUtilities/include)
-include_directories(${PROJECT_SOURCE_DIR}/src/xGadgetron/cGadgetron/include)
-
 add_library(cgadgetron cgadgetron.cpp gadgetron_x.cpp gadgetron_data_containers.cpp gadgetron_client.cpp ismrmrd_fftw.cpp)
 
 set (cGadgetron_INCLUDE_DIR "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>$<INSTALL_INTERFACE:include>")

--- a/src/xGadgetron/mGadgetron/CMakeLists.txt
+++ b/src/xGadgetron/mGadgetron/CMakeLists.txt
@@ -24,8 +24,6 @@ if(BUILD_MATLAB)
 
   include_directories("${Matlab_INCLUDE_DIRS}")
 
-  include_directories(${PROJECT_SOURCE_DIR}/src/common/include)
-
   add_library(mgadgetron SHARED mgadgetron.c)
   # fix output name and link flags
   SET_TARGET_PROPERTIES(mgadgetron PROPERTIES

--- a/src/xGadgetron/mGadgetron/gmi/CMakeLists.txt
+++ b/src/xGadgetron/mGadgetron/gmi/CMakeLists.txt
@@ -18,7 +18,6 @@
 
 if(BUILD_MATLAB)
 
-  include_directories(${PROJECT_SOURCE_DIR}/src/common/include)
   add_executable(gmi_xgadgetron gmi_xgadgetron.cpp)
   target_link_libraries(gmi_xgadgetron mig)
   INSTALL(TARGETS gmi_xgadgetron DESTINATION bin)

--- a/src/xGadgetron/pGadgetron/CMakeLists.txt
+++ b/src/xGadgetron/pGadgetron/CMakeLists.txt
@@ -21,8 +21,6 @@ if(BUILD_PYTHON)
   FIND_PACKAGE(SWIG REQUIRED)
   INCLUDE("${SWIG_USE_FILE}")
 
-  include_directories(${PROJECT_SOURCE_DIR}/src/common/include)
-
   SET_SOURCE_FILES_PROPERTIES(pygadgetron.i PROPERTIES CPLUSPLUS ON)  
   SET_SOURCE_FILES_PROPERTIES(pygadgetron.i PROPERTIES SWIG_FLAGS "-I${cGadgetron_INCLUDE_DIR}")
   # find libraries and include files

--- a/src/xSTIR/cSTIR/CMakeLists.txt
+++ b/src/xSTIR/cSTIR/CMakeLists.txt
@@ -20,10 +20,6 @@ set(CMAKE_POSITION_INDEPENDENT_CODE True)
 
 find_package(STIR REQUIRED)
 
-include_directories(${PROJECT_SOURCE_DIR}/src/common/include)
-include_directories(${PROJECT_SOURCE_DIR}/src/iUtilities/include)
-include_directories(${PROJECT_SOURCE_DIR}/src/xSTIR/cSTIR/include)
-
 add_library(cstir 
     cstir_p.cpp cstir_tw.cpp stir_data_containers.cpp stir_x.cpp cstir.cpp)
 target_include_directories(cstir PUBLIC

--- a/src/xSTIR/cSTIR/tests/CMakeLists.txt
+++ b/src/xSTIR/cSTIR/tests/CMakeLists.txt
@@ -23,7 +23,6 @@
 #    INSTALL_NAME_DIR "${PROJECT_NAME}")
 #TARGET_LINK_LIBRARIES(test4 PUBLIC cstir )
 
-  include_directories(${PROJECT_SOURCE_DIR}/src/common/include)
   add_executable(test4 ${CMAKE_CURRENT_SOURCE_DIR}/test4.cpp ${STIR_REGISTRIES})
   target_link_libraries(test4 cstir ${STIR_LIBRARIES})
   INSTALL(TARGETS test4 DESTINATION bin)

--- a/src/xSTIR/mSTIR/CMakeLists.txt
+++ b/src/xSTIR/mSTIR/CMakeLists.txt
@@ -22,9 +22,6 @@ if(BUILD_MATLAB)
 
   include_directories(${Matlab_INCLUDE_DIRS})
 
-  include_directories(${PROJECT_SOURCE_DIR}/src/common/include)
-  include_directories(${PROJECT_SOURCE_DIR}/src/iUtilities/include)
-
   add_library(mstir SHARED mstir.c printer.cpp  ${STIR_REGISTRIES})
   # fix output name and link flags
   SET_TARGET_PROPERTIES(mstir PROPERTIES

--- a/src/xSTIR/mSTIR/gmi/CMakeLists.txt
+++ b/src/xSTIR/mSTIR/gmi/CMakeLists.txt
@@ -22,7 +22,6 @@ if(BUILD_MATLAB)
 
   include_directories(${Matlab_INCLUDE_DIRS})
 
-  include_directories(${PROJECT_SOURCE_DIR}/src/common/include)
   add_executable(gmi_xstir gmi_xstir.cpp)
   target_link_libraries(gmi_xstir mig)
   INSTALL(TARGETS gmi_xstir DESTINATION bin)

--- a/src/xSTIR/pSTIR/CMakeLists.txt
+++ b/src/xSTIR/pSTIR/CMakeLists.txt
@@ -36,8 +36,6 @@ if(BUILD_PYTHON)
   SWIG_ADD_MODULE(pystir python pystir.i  ${STIR_REGISTRIES})
   SWIG_LINK_LIBRARIES(pystir cstir iutilities ${STIR_LIBRARIES} ${PYTHON_LIBRARIES})
 
-  include_directories(${PROJECT_SOURCE_DIR}/src/common/include)
-
   INSTALL(TARGETS ${SWIG_MODULE_pystir_REAL_NAME} DESTINATION "${PYTHON_DEST}/sirf")
   INSTALL(FILES "${CMAKE_CURRENT_BINARY_DIR}/pystir.py" STIR.py DESTINATION "${PYTHON_DEST}/sirf")
 


### PR DESCRIPTION
sirf/common is used throughout the code. makes sense to include it higher up, to avoid repetition.