### PR TITLE
[TRAVIS] Fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,12 +32,12 @@ matrix:
    env: EXTRA_BUILD_FLAGS="-DUSE_SYSTEM_Boost=OFF -DUSE_SYSTEM_FFTW3=ON -DUSE_SYSTEM_HDF5=ON -DBUILD_siemens_to_ismrmrd=ON -DUSE_SYSTEM_SWIG=ON" MATRIX_EVAL="CC=gcc-5 CXX=g++-5" PYMVER=2
  - os: linux
    python: 3
-   # +DEVEL -boost -hdf5 -fftw3 -ace +siemens_to_ismrmrd
-   env: EXTRA_BUILD_FLAGS="-DDEVEL_BUILD=ON -DUSE_SYSTEM_Boost=OFF -DUSE_SYSTEM_HDF5=OFF -DUSE_SYSTEM_FFTW3=OFF -DUSE_SYSTEM_ACE=OFF -DBUILD_siemens_to_ismrmrd=ON" MATRIX_EVAL="CC=gcc-6 CXX=g++-6" PYMVER=3
+   # +DEVEL -boost -hdf5 -fftw3 +ace +siemens_to_ismrmrd
+   env: EXTRA_BUILD_FLAGS="-DDEVEL_BUILD=ON -DUSE_SYSTEM_Boost=OFF -DUSE_SYSTEM_HDF5=OFF -DUSE_SYSTEM_FFTW3=OFF -DUSE_SYSTEM_ACE=ON -DBUILD_siemens_to_ismrmrd=ON" MATRIX_EVAL="CC=gcc-6 CXX=g++-6" PYMVER=3
  - os: linux
    python: 2.7
-   # +DEVEL -boost -fftw3 -hdf5 -swig -ace
-   env: EXTRA_BUILD_FLAGS="-DDEVEL_BUILD=ON -DUSE_SYSTEM_Boost=OFF -DUSE_SYSTEM_FFTW3=OFF -DUSE_SYSTEM_HDF5=OFF -DUSE_SYSTEM_ACE=OFF -DUSE_SYSTEM_SWIG=OFF" MATRIX_EVAL="CC=gcc-6 CXX=g++-6" PYMVER=2
+   # +DEVEL -boost -fftw3 -hdf5 -swig +ace
+   env: EXTRA_BUILD_FLAGS="-DDEVEL_BUILD=ON -DUSE_SYSTEM_Boost=OFF -DUSE_SYSTEM_FFTW3=OFF -DUSE_SYSTEM_HDF5=OFF -DUSE_SYSTEM_ACE=ON -DUSE_SYSTEM_SWIG=OFF" MATRIX_EVAL="CC=gcc-6 CXX=g++-6" PYMVER=2
  # osx g{cc,++} py{27,36}
  - os: osx
    python: 2.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ language: cpp
 
 # Environment variables
 # Note: On trusty we need to build Armadillo and boost ourselves (the system versions are too old)
+# Note: On OSX we can't test SYSTEM_Boost=OFF due to excessive log size (https://github.com/CCPPETMR/SIRF-SuperBuild/issues/167)
 # Note: altering the matrix here will cause re-building of caches,
 # so try to keep this concise to avoid need to update
 matrix:
@@ -26,21 +27,21 @@ matrix:
    env: EXTRA_BUILD_FLAGS="-DUSE_SYSTEM_Boost=OFF -DUSE_SYSTEM_FFTW3=ON -DUSE_SYSTEM_HDF5=ON -DBUILD_siemens_to_ismrmrd=ON -DUSE_SYSTEM_SWIG=ON" MATRIX_EVAL="CC=gcc-5 CXX=g++-5" PYMVER=2
  - os: linux
    python: 3
-   # +DEVEL -boost -hdf5 -fftw3 +siemens_to_ismrmrd
-   env: EXTRA_BUILD_FLAGS="-DDEVEL_BUILD=ON -DUSE_SYSTEM_Boost=OFF -DUSE_SYSTEM_HDF5=OFF -DUSE_SYSTEM_FFTW3=OFF -DBUILD_siemens_to_ismrmrd=ON" MATRIX_EVAL="CC=gcc-7 CXX=g++-7" PYMVER=3
+   # +DEVEL -boost -hdf5 -fftw3 -ace +siemens_to_ismrmrd
+   env: EXTRA_BUILD_FLAGS="-DDEVEL_BUILD=ON -DUSE_SYSTEM_Boost=OFF -DUSE_SYSTEM_HDF5=OFF -DUSE_SYSTEM_FFTW3=OFF -DUSE_SYSTEM_ACE=OFF -DBUILD_siemens_to_ismrmrd=ON" MATRIX_EVAL="CC=gcc-7 CXX=g++-7" PYMVER=3
  - os: linux
    python: 2.7
-   # +DEVEL -boost -fftw3 -hdf5 -swig
-   env: EXTRA_BUILD_FLAGS="-DDEVEL_BUILD=ON -DUSE_SYSTEM_Boost=OFF -DUSE_SYSTEM_FFTW3=OFF -DUSE_SYSTEM_HDF5=OFF -DUSE_SYSTEM_SWIG=OFF" MATRIX_EVAL="CC=gcc-7 CXX=g++-7" PYMVER=2
+   # +DEVEL -boost -fftw3 -hdf5 -swig -ace
+   env: EXTRA_BUILD_FLAGS="-DDEVEL_BUILD=ON -DUSE_SYSTEM_Boost=OFF -DUSE_SYSTEM_FFTW3=OFF -DUSE_SYSTEM_HDF5=OFF -DUSE_SYSTEM_ACE=OFF -DUSE_SYSTEM_SWIG=OFF" MATRIX_EVAL="CC=gcc-7 CXX=g++-7" PYMVER=2
  # osx g{cc,++} py{27,36}
  - os: osx
    python: 2.7
    # +boost -hdf5 -swig
    env: EXTRA_BUILD_FLAGS="-DUSE_SYSTEM_Boost=ON -DUSE_SYSTEM_HDF5=OFF -DUSE_SYSTEM_SWIG=OFF" MATRIX_EVAL="CC=gcc CXX=g++" PYMVER=2
  - os: osx
-   # -boost -hdf5 -swig
+   # +boost +fftw3 -hdf5 -swig
    python: 3
-   env: EXTRA_BUILD_FLAGS="-DUSE_SYSTEM_Boost=OFF -DUSE_SYSTEM_HDF5=OFF -DUSE_SYSTEM_SWIG=OFF" MATRIX_EVAL="CC=gcc CXX=g++" PYMVER=3
+   env: EXTRA_BUILD_FLAGS="-DUSE_SYSTEM_Boost=ON -DUSE_SYSTEM_FFTW3=ON -DUSE_SYSTEM_HDF5=OFF -DUSE_SYSTEM_SWIG=OFF" MATRIX_EVAL="CC=gcc CXX=g++" PYMVER=3
  - os: osx
    python: 2.7
    # +DEVEL +boost -hdf5 +swig
@@ -97,6 +98,8 @@ addons:
    - libplplot-dev
    - swig
    - ccache
+   # for building ACE (note: Trusty only)
+   - realpath
    # not in whitelist
    - libxslt-dev
    - libace-dev
@@ -153,6 +156,11 @@ before_install:
         brew install ace
         brew install swig
         brew install ccache
+        if [[ $EXTRA_BUILD_FLAGS == *"SYSTEM_FFTW3=ON"* ]]; then
+            brew install fftw
+        else
+            echo "Not installing FFTW as we are building it"
+        fi
         # need curl to get pip and more recent cmake
         brew install curl
         #brew install cmake # already present
@@ -221,6 +229,7 @@ script:
  - cat builds/SIRF/build/Testing/Temporary/LastTest.log
  # may exceed 4MB travis log limit
  - cat gadgetron.log
+
 
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -167,14 +167,16 @@ before_install:
         # alternative: get our own
         #curl -0 https://cmake.org/files/v3.8/cmake-3.8.0-Darwin-x86_64.tar.gz -o cmake.tar.gz
         #tar xzf cmake.tar.gz
-        #mv cmake-*/CMake.app/Contents/* cmake-*
-        #export PATH="$PWD/cmake-*/bin:$PATH"
+        #mv cmake-*/CMake.app/Contents/* cmake
+        #export PATH="$PWD/cmake/bin:$PATH"
       )
     elif [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
       PY_EXE=python$PYMVER
-      curl -0 https://cmake.org/files/v3.7/cmake-3.7.2-Linux-x86_64.tar.gz -o cmake.tar.gz
-      tar xzf cmake.tar.gz
-      export PATH="$PWD/cmake-*/bin:$PATH"
+      curl -L -O https://github.com/Kitware/CMake/releases/download/v3.13.1/cmake-3.13.1-Linux-x86_64.tar.gz
+      ls -l cmake-*
+      tar xzf cmake-*.tar.gz
+      mv cmake-*x86_64 cmake
+      export PATH="$PWD/cmake/bin:$PATH"
     fi
  - echo "Using Python executable $PY_EXE"
  # get pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,11 +12,16 @@ language: cpp
 # Environment variables
 # Note: On trusty we need to build Armadillo and boost ourselves (the system versions are too old)
 # Note: On OSX we can't test SYSTEM_Boost=OFF due to excessive log size (https://github.com/CCPPETMR/SIRF-SuperBuild/issues/167)
+# Note: currently ACE is not building correctly, so ACE is not built on any configuration https://github.com/CCPPETMR/SIRF-SuperBuild/issues/#174
+# Note: on Trusty, g++-7 causes errors with the system ACE, so cannot use g++-7 or later https://github.com/CCPPETMR/SIRF-SuperBuild/issues/169
 # Note: altering the matrix here will cause re-building of caches,
 # so try to keep this concise to avoid need to update
+# Note: the line above each `env` contains a resume of the parameters passed to cmake.
+#       + or - refer to the value of the parameter affecting the specific package is passed to cmake:
+#       i.e. -boost == -DUSE_SYSTEM_Boost=OFF, which means that Boost will be built.
 matrix:
  include:
- # linux g{cc,++}-{5,7} py{27,3}
+ # linux g{cc,++}-{5,6} py{27,3}
  - os: linux
    python: 3
    # -boost +fftw3 +hdf5
@@ -28,11 +33,11 @@ matrix:
  - os: linux
    python: 3
    # +DEVEL -boost -hdf5 -fftw3 -ace +siemens_to_ismrmrd
-   env: EXTRA_BUILD_FLAGS="-DDEVEL_BUILD=ON -DUSE_SYSTEM_Boost=OFF -DUSE_SYSTEM_HDF5=OFF -DUSE_SYSTEM_FFTW3=OFF -DUSE_SYSTEM_ACE=OFF -DBUILD_siemens_to_ismrmrd=ON" MATRIX_EVAL="CC=gcc-7 CXX=g++-7" PYMVER=3
+   env: EXTRA_BUILD_FLAGS="-DDEVEL_BUILD=ON -DUSE_SYSTEM_Boost=OFF -DUSE_SYSTEM_HDF5=OFF -DUSE_SYSTEM_FFTW3=OFF -DUSE_SYSTEM_ACE=OFF -DBUILD_siemens_to_ismrmrd=ON" MATRIX_EVAL="CC=gcc-6 CXX=g++-6" PYMVER=3
  - os: linux
    python: 2.7
    # +DEVEL -boost -fftw3 -hdf5 -swig -ace
-   env: EXTRA_BUILD_FLAGS="-DDEVEL_BUILD=ON -DUSE_SYSTEM_Boost=OFF -DUSE_SYSTEM_FFTW3=OFF -DUSE_SYSTEM_HDF5=OFF -DUSE_SYSTEM_ACE=OFF -DUSE_SYSTEM_SWIG=OFF" MATRIX_EVAL="CC=gcc-7 CXX=g++-7" PYMVER=2
+   env: EXTRA_BUILD_FLAGS="-DDEVEL_BUILD=ON -DUSE_SYSTEM_Boost=OFF -DUSE_SYSTEM_FFTW3=OFF -DUSE_SYSTEM_HDF5=OFF -DUSE_SYSTEM_ACE=OFF -DUSE_SYSTEM_SWIG=OFF" MATRIX_EVAL="CC=gcc-6 CXX=g++-6" PYMVER=2
  # osx g{cc,++} py{27,36}
  - os: osx
    python: 2.7
@@ -81,7 +86,7 @@ addons:
    - git-core
    - build-essential
    - g++-5
-   - g++-7
+   - g++-6
    - libboost-all-dev
    - libhdf5-serial-dev
    - libfftw3-dev
@@ -198,10 +203,10 @@ before_install:
  # ccache compiler override
  - ln -s "$(which ccache)" g++
  - ln -s "$(which ccache)" g++-5
- - ln -s "$(which ccache)" g++-7
+ - ln -s "$(which ccache)" g++-6
  - ln -s "$(which ccache)" gcc
  - ln -s "$(which ccache)" gcc-5
- - ln -s "$(which ccache)" gcc-7
+ - ln -s "$(which ccache)" gcc-6
  - export PATH="$PWD:$PATH"
  - popd
  # Use Travis' currently checked-out SIRF commit ID to build.

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,49 +15,49 @@ language: cpp
 # so try to keep this concise to avoid need to update
 matrix:
  include:
- # linux g{cc,++}-5 py{27,3}
+ # linux g{cc,++}-{5,7} py{27,3}
  - os: linux
    python: 3
    # -boost +fftw3 +hdf5
-   env: EXTRA_BUILD_FLAGS="-DUSE_SYSTEM_Boost=OFF -DUSE_SYSTEM_FFTW3=ON -DUSE_SYSTEM_HDF5=ON" CC=gcc-5 CXX=g++-5 PYMVER=3
+   env: EXTRA_BUILD_FLAGS="-DUSE_SYSTEM_Boost=OFF -DUSE_SYSTEM_FFTW3=ON -DUSE_SYSTEM_HDF5=ON" MATRIX_EVAL="CC=gcc-5 CXX=g++-5" PYMVER=3
  - os: linux
    python: 2.7
    # -boost +fftw3 +hdf5 +siemens_to_ismrmrd +swig
-   env: EXTRA_BUILD_FLAGS="-DUSE_SYSTEM_Boost=OFF -DUSE_SYSTEM_FFTW3=ON -DUSE_SYSTEM_HDF5=ON -DBUILD_siemens_to_ismrmrd=ON -DUSE_SYSTEM_SWIG=ON" CC=gcc-5 CXX=g++-5 PYMVER=2
+   env: EXTRA_BUILD_FLAGS="-DUSE_SYSTEM_Boost=OFF -DUSE_SYSTEM_FFTW3=ON -DUSE_SYSTEM_HDF5=ON -DBUILD_siemens_to_ismrmrd=ON -DUSE_SYSTEM_SWIG=ON" MATRIX_EVAL="CC=gcc-5 CXX=g++-5" PYMVER=2
  - os: linux
    python: 3
    # +DEVEL -boost -hdf5 -fftw3 +siemens_to_ismrmrd
-   env: EXTRA_BUILD_FLAGS="-DDEVEL_BUILD=ON -DUSE_SYSTEM_Boost=OFF -DUSE_SYSTEM_HDF5=OFF -DUSE_SYSTEM_FFTW3=OFF -DBUILD_siemens_to_ismrmrd=ON" CC=gcc-5 CXX=g++-5 PYMVER=3
+   env: EXTRA_BUILD_FLAGS="-DDEVEL_BUILD=ON -DUSE_SYSTEM_Boost=OFF -DUSE_SYSTEM_HDF5=OFF -DUSE_SYSTEM_FFTW3=OFF -DBUILD_siemens_to_ismrmrd=ON" MATRIX_EVAL="CC=gcc-7 CXX=g++-7" PYMVER=3
  - os: linux
    python: 2.7
    # +DEVEL -boost -fftw3 -hdf5 -swig
-   env: EXTRA_BUILD_FLAGS="-DDEVEL_BUILD=ON -DUSE_SYSTEM_Boost=OFF -DUSE_SYSTEM_FFTW3=OFF -DUSE_SYSTEM_HDF5=OFF -DUSE_SYSTEM_SWIG=OFF" CC=gcc-5 CXX=g++-5 PYMVER=2
+   env: EXTRA_BUILD_FLAGS="-DDEVEL_BUILD=ON -DUSE_SYSTEM_Boost=OFF -DUSE_SYSTEM_FFTW3=OFF -DUSE_SYSTEM_HDF5=OFF -DUSE_SYSTEM_SWIG=OFF" MATRIX_EVAL="CC=gcc-7 CXX=g++-7" PYMVER=2
  # osx g{cc,++} py{27,36}
  - os: osx
    python: 2.7
    # +boost -hdf5 -swig
-   env: EXTRA_BUILD_FLAGS="-DUSE_SYSTEM_Boost=ON -DUSE_SYSTEM_HDF5=OFF -DUSE_SYSTEM_SWIG=OFF" CC=gcc CXX=g++ PYMVER=2
+   env: EXTRA_BUILD_FLAGS="-DUSE_SYSTEM_Boost=ON -DUSE_SYSTEM_HDF5=OFF -DUSE_SYSTEM_SWIG=OFF" MATRIX_EVAL="CC=gcc CXX=g++" PYMVER=2
  - os: osx
    # -boost -hdf5 -swig
    python: 3
-   env: EXTRA_BUILD_FLAGS="-DUSE_SYSTEM_Boost=OFF -DUSE_SYSTEM_HDF5=OFF -DUSE_SYSTEM_SWIG=OFF" CC=gcc CXX=g++ PYMVER=3
+   env: EXTRA_BUILD_FLAGS="-DUSE_SYSTEM_Boost=OFF -DUSE_SYSTEM_HDF5=OFF -DUSE_SYSTEM_SWIG=OFF" MATRIX_EVAL="CC=gcc CXX=g++" PYMVER=3
  - os: osx
    python: 2.7
    # +DEVEL +boost -hdf5 +swig
-   env: EXTRA_BUILD_FLAGS="-DDEVEL_BUILD=ON -DUSE_SYSTEM_Boost=ON -DUSE_SYSTEM_HDF5=OFF -DUSE_SYSTEM_SWIG=ON" CC=gcc CXX=g++ PYMVER=2
+   env: EXTRA_BUILD_FLAGS="-DDEVEL_BUILD=ON -DUSE_SYSTEM_Boost=ON -DUSE_SYSTEM_HDF5=OFF -DUSE_SYSTEM_SWIG=ON" MATRIX_EVAL="CC=gcc CXX=g++" PYMVER=2
  - os: osx
    python: 2.7
    # +DEVEL +boost -fftw3 -hdf5 +swig
-   env: EXTRA_BUILD_FLAGS="-DDEVEL_BUILD=ON -DUSE_SYSTEM_Boost=ON -DUSE_SYSTEM_FFTW3=OFF -DUSE_SYSTEM_HDF5=OFF -DUSE_SYSTEM_SWIG=ON" CC=gcc CXX=g++ PYMVER=2
+   env: EXTRA_BUILD_FLAGS="-DDEVEL_BUILD=ON -DUSE_SYSTEM_Boost=ON -DUSE_SYSTEM_FFTW3=OFF -DUSE_SYSTEM_HDF5=OFF -DUSE_SYSTEM_SWIG=ON" MATRIX_EVAL="CC=gcc CXX=g++" PYMVER=2
  # itk
  - os: linux
    python: 3
    # -boost +itk +fftw3 +hdf5
-   env: EXTRA_BUILD_FLAGS="-DUSE_SYSTEM_Boost=OFF -DUSE_ITK=ON -DUSE_SYSTEM_FFTW3=ON -DUSE_SYSTEM_HDF5=ON" CC=gcc-5 CXX=g++-5 PYMVER=3
+   env: EXTRA_BUILD_FLAGS="-DUSE_SYSTEM_Boost=OFF -DUSE_ITK=ON -DUSE_SYSTEM_FFTW3=ON -DUSE_SYSTEM_HDF5=ON" MATRIX_EVAL="CC=gcc-5 CXX=g++-5" PYMVER=3
  - os: osx
    python: 2.7
    # +boost +itk -hdf5 +swig
-   env: EXTRA_BUILD_FLAGS="-DUSE_SYSTEM_Boost=ON -DUSE_ITK=ON -DUSE_SYSTEM_HDF5=OFF -DUSE_SYSTEM_SWIG=ON" CC=gcc CXX=g++ PYMVER=2
+   env: EXTRA_BUILD_FLAGS="-DUSE_SYSTEM_Boost=ON -DUSE_ITK=ON -DUSE_SYSTEM_HDF5=OFF -DUSE_SYSTEM_SWIG=ON" MATRIX_EVAL="CC=gcc CXX=g++" PYMVER=2
 
 env:
  global:
@@ -80,6 +80,7 @@ addons:
    - git-core
    - build-essential
    - g++-5
+   - g++-7
    - libboost-all-dev
    - libhdf5-serial-dev
    - libfftw3-dev
@@ -87,6 +88,8 @@ addons:
    - python3-dev
    - python-tk
    - python3-tk
+   - libopenblas-dev
+   - libatlas-base-dev
    - liblapack-dev
    - libxml2-dev
    - libarmadillo-dev
@@ -105,6 +108,11 @@ cache:
   - pip
 
 before_install:
+ # Set C and C++ compiler etc using trick from
+ # https://docs.travis-ci.com/user/languages/cpp/#c11c11-and-beyond-and-toolchain-versioning
+ - eval "${MATRIX_EVAL}"
+ - $CC --version
+ - $CXX --version
  - mkdir -p ~/.local/bin
  - pushd ~/.local/bin
  # Note: use ( set -ev; ... ) to echo commands and exit immediately on failure
@@ -180,8 +188,10 @@ before_install:
  # ccache compiler override
  - ln -s "$(which ccache)" g++
  - ln -s "$(which ccache)" g++-5
+ - ln -s "$(which ccache)" g++-7
  - ln -s "$(which ccache)" gcc
  - ln -s "$(which ccache)" gcc-5
+ - ln -s "$(which ccache)" gcc-7
  - export PATH="$PWD:$PATH"
  - popd
  # Use Travis' currently checked-out SIRF commit ID to build.


### PR DESCRIPTION
- use gcc-6 on Linux for DEVEL_BUILD (and gcc-5 otherwise)
- upgrade to CMake 3.13
- always build Boost as requirement too high for Trusty

See https://github.com/CCPPETMR/SIRF-SuperBuild/pull/176 for original commits