### PR TITLE
Pure virtual method write for ImageData

### DIFF
--- a/src/common/include/sirf/common/ImageData.h
+++ b/src/common/include/sirf/common/ImageData.h
@@ -56,6 +56,8 @@ namespace sirf {
             for (; dst != end; ++dst, ++src)
 				*dst = *src;
         }
+        /// Write image to file
+        virtual void write(const std::string &filename) const = 0;
 	};
 }
 

--- a/src/xGadgetron/cGadgetron/gadgetron_data_containers.cpp
+++ b/src/xGadgetron/cGadgetron/gadgetron_data_containers.cpp
@@ -1008,7 +1008,7 @@ GadgetronImageData::read(std::string filename)
 }
 
 void
-GadgetronImageData::write(std::string filename, std::string groupname) const
+GadgetronImageData::write(const std::string &filename, const std::string &groupname) const
 {
 	//if (images_.size() < 1)
 	if (number() < 1)

--- a/src/xGadgetron/cGadgetron/gadgetron_data_containers.cpp
+++ b/src/xGadgetron/cGadgetron/gadgetron_data_containers.cpp
@@ -1008,7 +1008,7 @@ GadgetronImageData::read(std::string filename)
 }
 
 void
-GadgetronImageData::write(std::string filename, std::string groupname)
+GadgetronImageData::write(std::string filename, std::string groupname) const
 {
 	//if (images_.size() < 1)
 	if (number() < 1)

--- a/src/xGadgetron/cGadgetron/include/sirf/cGadgetron/gadgetron_data_containers.h
+++ b/src/xGadgetron/cGadgetron/include/sirf/cGadgetron/gadgetron_data_containers.h
@@ -407,7 +407,7 @@ namespace sirf {
 		virtual void get_real_data(float* data) const;
 		virtual void set_real_data(const float* data);
 		virtual int read(std::string filename);
-		virtual void write(std::string filename, std::string groupname) const;
+		virtual void write(const std::string &filename, const std::string &groupname) const;
         virtual void write(const std::string &filename) const { this->write(filename,"dataset"); }
 		virtual Dimensions dimensions() const 
 		{

--- a/src/xGadgetron/cGadgetron/include/sirf/cGadgetron/gadgetron_data_containers.h
+++ b/src/xGadgetron/cGadgetron/include/sirf/cGadgetron/gadgetron_data_containers.h
@@ -407,7 +407,8 @@ namespace sirf {
 		virtual void get_real_data(float* data) const;
 		virtual void set_real_data(const float* data);
 		virtual int read(std::string filename);
-		virtual void write(std::string filename, std::string groupname);
+		virtual void write(std::string filename, std::string groupname) const;
+        virtual void write(const std::string &filename) const { this->write(filename,"dataset"); }
 		virtual Dimensions dimensions() const 
 		{
 			Dimensions dim;

--- a/src/xGadgetron/pGadgetron/Gadgetron.py
+++ b/src/xGadgetron/pGadgetron/Gadgetron.py
@@ -536,7 +536,7 @@ class ImageData(SIRF.ImageData):
         return ip.process(self)
     def image(self, im_num):
         return Image(self, im_num)
-    def write(self, out_file, out_group):
+    def write(self, out_file, out_group='dataset'):
         '''
         Writes self's images to an hdf5 file.
         out_file : the file name (Python string)

--- a/src/xSTIR/cSTIR/cstir.cpp
+++ b/src/xSTIR/cSTIR/cstir.cpp
@@ -888,10 +888,7 @@ void* cSTIR_writeImage(void* ptr_i, const char* filename)
 {
 	try {
 		STIRImageData& id = objectFromHandle<STIRImageData>(ptr_i);
-		Image3DF& image = id.data();
-		shared_ptr<OutputFileFormat<Image3DF> > format_sptr =
-			OutputFileFormat<Image3DF>::default_sptr();
-		format_sptr->write_to_file(filename, image);
+		id.write(filename);
 		return (void*) new DataHandle;
 	}
 	CATCH;

--- a/src/xSTIR/cSTIR/include/sirf/cSTIR/stir_data_containers.h
+++ b/src/xSTIR/cSTIR/include/sirf/cSTIR/stir_data_containers.h
@@ -650,6 +650,8 @@ namespace sirf {
 		{
 			return 1;
 		}
+        /// Write to file
+        virtual void write(const std::string &filename) const;
 
 		virtual void dot(const DataContainer& a_x, void* ptr);
 		virtual void axpby(

--- a/src/xSTIR/cSTIR/stir_data_containers.cpp
+++ b/src/xSTIR/cSTIR/stir_data_containers.cpp
@@ -347,6 +347,15 @@ const DataContainer& a_y
 }
 
 void
+STIRImageData::write(const std::string &filename) const
+{
+    const Image3DF& image = this->data();
+    shared_ptr<OutputFileFormat<Image3DF> > format_sptr =
+        OutputFileFormat<Image3DF>::default_sptr();
+    format_sptr->write_to_file(filename, image);
+}
+
+void
 STIRImageData::dot(const DataContainer& a_x, void* ptr)
 {
 	STIRImageData& x = (STIRImageData&)a_x;


### PR DESCRIPTION
This needs to be here so that the registration/resampling can return any image type, and that image type can be saved to file.