### PR TITLE
Use target_include_directories

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,7 +121,7 @@ endif()
 ENABLE_TESTING()
 
 ADD_SUBDIRECTORY(src/iUtilities)
+ADD_SUBDIRECTORY(src/common)
 ADD_SUBDIRECTORY(src/xSTIR)
 ADD_SUBDIRECTORY(src/xGadgetron)
-ADD_SUBDIRECTORY(src/common)
 include("${CMAKE_CURRENT_SOURCE_DIR}/cmake/setup.py.cmake")

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -21,14 +21,15 @@ set(CMAKE_POSITION_INDEPENDENT_CODE True)
 
 set(cSIRF_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
 
-include_directories(${PROJECT_SOURCE_DIR}/src/common/include)
-include_directories(${PROJECT_SOURCE_DIR}/src/iUtilities/include)
 
 add_library(csirf csirf.cpp)
 target_include_directories(csirf PUBLIC
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>$<INSTALL_INTERFACE:include>"
   )
-target_link_libraries(csirf iutilities)
+target_include_directories(csirf PUBLIC
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>$<INSTALL_INTERFACE:include>"
+  )
+target_link_libraries(csirf PUBLIC iutilities)
 
 if (BUILD_PYTHON)
 

--- a/src/iUtilities/CMakeLists.txt
+++ b/src/iUtilities/CMakeLists.txt
@@ -18,12 +18,12 @@
 
 set(CMAKE_POSITION_INDEPENDENT_CODE True)
 
-include_directories(${PROJECT_SOURCE_DIR}/src/common/include)
-include_directories(${PROJECT_SOURCE_DIR}/src/iUtilities/include)
-
 add_library(iutilities iutilities.cpp)
 target_include_directories(iutilities PUBLIC
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>$<INSTALL_INTERFACE:include>"
+  )
+target_include_directories(iutilities PUBLIC
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>$<INSTALL_INTERFACE:include>"
   )
 
 if(BUILD_PYTHON)

--- a/src/iUtilities/gmi/CMakeLists.txt
+++ b/src/iUtilities/gmi/CMakeLists.txt
@@ -22,9 +22,8 @@ if(BUILD_MATLAB)
 
   include_directories(${Matlab_INCLUDE_DIRS})
 
-  include_directories(${PROJECT_SOURCE_DIR}/src/common/include)
   add_executable(gmi_iutilities gmi.cpp)
-  target_link_libraries(gmi_iutilities mig)
+  target_link_libraries(gmi_iutilities csirf mig)
   INSTALL(TARGETS gmi_iutilities DESTINATION bin)
 
 endif(BUILD_MATLAB)

--- a/src/xGadgetron/CMakeLists.txt
+++ b/src/xGadgetron/CMakeLists.txt
@@ -27,6 +27,7 @@ endif ()
 find_package(ISMRMRD)
 if (ISMRMRD_FOUND)
   set(CMAKE_MODULE_PATH "${ISMRMRD_DIR}")
+  set(cGadgetron_LIBRARY_DIRS "${ISMRMRD_LIBRARY_DIRS}" PARENT_SCOPE)
 
   find_package(FFTW3 COMPONENTS single REQUIRED)
 
@@ -43,8 +44,6 @@ endif()
   include_directories("${ISMRMRD_INCLUDE_DIR}")
   # need to add this as ISMRMRD_LIBRARIES doesn't set the path to the library
   link_directories("${ISMRMRD_LIBRARY_DIRS}")
-
-  include_directories(${PROJECT_SOURCE_DIR}/src/common/include)
 
   ADD_SUBDIRECTORY(cGadgetron)
 

--- a/src/xGadgetron/cGadgetron/CMakeLists.txt
+++ b/src/xGadgetron/cGadgetron/CMakeLists.txt
@@ -32,20 +32,17 @@ if (SIRF_INSTALL_DEPENDENCIES AND WIN32)
 	endforeach()
   endif()
 	
-include_directories(${PROJECT_SOURCE_DIR}/src/common/include)
-include_directories(${PROJECT_SOURCE_DIR}/src/iUtilities/include)
-include_directories(${PROJECT_SOURCE_DIR}/src/xGadgetron/cGadgetron/include)
-
 add_library(cgadgetron cgadgetron.cpp gadgetron_x.cpp gadgetron_data_containers.cpp gadgetron_client.cpp ismrmrd_fftw.cpp)
 
-set (cGadgetron_INCLUDE_DIR "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>$<INSTALL_INTERFACE:include>")
+set (cGadgetron_INCLUDE_DIR "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>$<INSTALL_INTERFACE:include>")
+target_include_directories(cgadgetron PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>$<INSTALL_INTERFACE:include>")
 # copy to parent scope
 #set (cGadgetron_INCLUDE_DIR "${cGadgetron_INCLUDE_DIR}" PARENT_SCOPE)
 
 target_include_directories(cgadgetron PUBLIC "${cGadgetron_INCLUDE_DIR}")
 target_include_directories(cgadgetron PRIVATE "${FFTW3_INCLUDE_DIR}")
 
-target_link_libraries(cgadgetron iutilities)
+target_link_libraries(cgadgetron iutilities csirf)
 # Add boost library dependencies
 if((CMAKE_VERSION VERSION_LESS 3.5.0) OR (NOT _Boost_IMPORTED_TARGETS))
   # This is harder than it should be on older CMake versions to be able to cope with

--- a/src/xGadgetron/mGadgetron/CMakeLists.txt
+++ b/src/xGadgetron/mGadgetron/CMakeLists.txt
@@ -24,13 +24,11 @@ if(BUILD_MATLAB)
 
   include_directories("${Matlab_INCLUDE_DIRS}")
 
-  include_directories(${PROJECT_SOURCE_DIR}/src/common/include)
-
   add_library(mgadgetron SHARED mgadgetron.c)
   # fix output name and link flags
   SET_TARGET_PROPERTIES(mgadgetron PROPERTIES
         SUFFIX ".${MATLAB_MEX_EXT}" PREFIX "${MATLAB_PREFIX}") 
-  target_link_libraries(mgadgetron  cgadgetron iutilities ${FFTW3_LIBRARY} ${ISMRMRD_LIBRARIES} ${Boost_LIBRARIES} ${Matlab_LIBRARIES} )
+  target_link_libraries(mgadgetron csirf cgadgetron iutilities ${FFTW3_LIBRARY} ${ISMRMRD_LIBRARIES} ${Boost_LIBRARIES} ${Matlab_LIBRARIES} )
 
   INSTALL(TARGETS mgadgetron DESTINATION "${MATLAB_DEST}")
   INSTALL(FILES mgadgetron.h DESTINATION "${MATLAB_DEST}")

--- a/src/xGadgetron/mGadgetron/gmi/CMakeLists.txt
+++ b/src/xGadgetron/mGadgetron/gmi/CMakeLists.txt
@@ -18,9 +18,8 @@
 
 if(BUILD_MATLAB)
 
-  include_directories(${PROJECT_SOURCE_DIR}/src/common/include)
   add_executable(gmi_xgadgetron gmi_xgadgetron.cpp)
-  target_link_libraries(gmi_xgadgetron mig)
+  target_link_libraries(gmi_xgadgetron mig csirf)
   INSTALL(TARGETS gmi_xgadgetron DESTINATION bin)
 
 endif(BUILD_MATLAB)

--- a/src/xSTIR/CMakeLists.txt
+++ b/src/xSTIR/CMakeLists.txt
@@ -28,6 +28,9 @@ if (STIR_FOUND)
   ADD_SUBDIRECTORY(pSTIR)
   ADD_SUBDIRECTORY(mSTIR)
 
+  # Going to need this elsewhere
+  SET(STIR_REGISTRIES ${STIR_REGISTRIES} PARENT_SCOPE)
+
 else()
 
   message(WARNING "STIR not found. This is probably not what you want. If you need it, set STIR_DIR.")

--- a/src/xSTIR/cSTIR/CMakeLists.txt
+++ b/src/xSTIR/cSTIR/CMakeLists.txt
@@ -20,16 +20,14 @@ set(CMAKE_POSITION_INDEPENDENT_CODE True)
 
 find_package(STIR REQUIRED)
 
-include_directories(${PROJECT_SOURCE_DIR}/src/common/include)
-include_directories(${PROJECT_SOURCE_DIR}/src/iUtilities/include)
-include_directories(${PROJECT_SOURCE_DIR}/src/xSTIR/cSTIR/include)
-
 add_library(cstir 
     cstir_p.cpp cstir_tw.cpp stir_data_containers.cpp stir_x.cpp cstir.cpp)
 target_include_directories(cstir PUBLIC
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>$<INSTALL_INTERFACE:include>")
+target_include_directories(cstir PUBLIC
     "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>$<INSTALL_INTERFACE:include>")
 
-target_link_libraries(cstir iutilities)
+target_link_libraries(cstir csirf iutilities)
 target_link_libraries(cstir "${STIR_LIBRARIES}")
 # Add boost library dependencies
 if((CMAKE_VERSION VERSION_LESS 3.5.0) OR (NOT _Boost_IMPORTED_TARGETS))

--- a/src/xSTIR/cSTIR/tests/CMakeLists.txt
+++ b/src/xSTIR/cSTIR/tests/CMakeLists.txt
@@ -23,9 +23,8 @@
 #    INSTALL_NAME_DIR "${PROJECT_NAME}")
 #TARGET_LINK_LIBRARIES(test4 PUBLIC cstir )
 
-  include_directories(${PROJECT_SOURCE_DIR}/src/common/include)
   add_executable(test4 ${CMAKE_CURRENT_SOURCE_DIR}/test4.cpp ${STIR_REGISTRIES})
-  target_link_libraries(test4 cstir ${STIR_LIBRARIES})
+  target_link_libraries(test4 csirf cstir ${STIR_LIBRARIES})
   INSTALL(TARGETS test4 DESTINATION bin)
 
 ADD_TEST(NAME PET_TEST_CPLUSPLUS COMMAND test4 WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})

--- a/src/xSTIR/mSTIR/CMakeLists.txt
+++ b/src/xSTIR/mSTIR/CMakeLists.txt
@@ -22,14 +22,11 @@ if(BUILD_MATLAB)
 
   include_directories(${Matlab_INCLUDE_DIRS})
 
-  include_directories(${PROJECT_SOURCE_DIR}/src/common/include)
-  include_directories(${PROJECT_SOURCE_DIR}/src/iUtilities/include)
-
   add_library(mstir SHARED mstir.c printer.cpp  ${STIR_REGISTRIES})
   # fix output name and link flags
   SET_TARGET_PROPERTIES(mstir PROPERTIES
         SUFFIX ".${MATLAB_MEX_EXT}" PREFIX "${MATLAB_PREFIX}") 
-  target_link_libraries(mstir  cstir iutilities ${STIR_LIBRARIES} ${Matlab_LIBRARIES})
+  target_link_libraries(mstir csirf cstir iutilities ${STIR_LIBRARIES} ${Matlab_LIBRARIES})
   INSTALL(TARGETS mstir DESTINATION "${MATLAB_DEST}")
   INSTALL(FILES mstir.h DESTINATION "${MATLAB_DEST}")
   INSTALL(DIRECTORY +mSTIR DESTINATION "${MATLAB_DEST}")

--- a/src/xSTIR/mSTIR/gmi/CMakeLists.txt
+++ b/src/xSTIR/mSTIR/gmi/CMakeLists.txt
@@ -22,9 +22,8 @@ if(BUILD_MATLAB)
 
   include_directories(${Matlab_INCLUDE_DIRS})
 
-  include_directories(${PROJECT_SOURCE_DIR}/src/common/include)
   add_executable(gmi_xstir gmi_xstir.cpp)
-  target_link_libraries(gmi_xstir mig)
+  target_link_libraries(gmi_xstir csirf mig)
   INSTALL(TARGETS gmi_xstir DESTINATION bin)
 
 endif(BUILD_MATLAB)

--- a/src/xSTIR/pSTIR/CMakeLists.txt
+++ b/src/xSTIR/pSTIR/CMakeLists.txt
@@ -34,9 +34,7 @@ if(BUILD_PYTHON)
   # Tell CMake it needs to re-run SWIG when .h file changes
   set(SWIG_MODULE_pystir_EXTRA_DEPS "${cSTIR_INCLUDE_DIR}/cstir.h")
   SWIG_ADD_MODULE(pystir python pystir.i  ${STIR_REGISTRIES})
-  SWIG_LINK_LIBRARIES(pystir cstir iutilities ${STIR_LIBRARIES} ${PYTHON_LIBRARIES})
-
-  include_directories(${PROJECT_SOURCE_DIR}/src/common/include)
+  SWIG_LINK_LIBRARIES(pystir csirf cstir iutilities ${STIR_LIBRARIES} ${PYTHON_LIBRARIES})
 
   INSTALL(TARGETS ${SWIG_MODULE_pystir_REAL_NAME} DESTINATION "${PYTHON_DEST}/sirf")
   INSTALL(FILES "${CMAKE_CURRENT_BINARY_DIR}/pystir.py" STIR.py DESTINATION "${PYTHON_DEST}/sirf")


### PR DESCRIPTION
Following from #250, if `target_include_directories` is used, then the header files will be available when a library is linked.

Some `.h` files are still at the same level as the `.cpp` files, whereas the majority are in `include/sirf/engine`. This means that for the time being, we need to include to directories per library.