### PR TITLE
Clone as sptr

### DIFF
--- a/doc/DeveloperGuide.md
+++ b/doc/DeveloperGuide.md
@@ -21,6 +21,7 @@
 	1. [Naming](#conventions_naming)
 	2. [File conventions](#conventions_file)
 	3. [Others](#conventions_others)
+6. [Cloning data container](#clone_datacontainer)
 
 # Overview <a name="Overview"></a>
 
@@ -445,3 +446,8 @@ The programming style used in SIRF resembles closely that used in STIR. When imp
 * Access to all class data should be achieved via `get` and `set` methods.
 * If outputs are passed as an argument (via reference or pointer), put them first in the list of arguments.
 * Error handling should be performed via try/catch statements.
+
+# Cloning data container <a name="clone_datacontainer"></a>
+This section should hopefully clear up a bit of confusion around the way cloning an image/acquisition data in SIRF.
+
+We often store an image/acquisition data as a more general version of itself. For example, we might store a `STIRImageData` as an `ImageData`. However, we need to be able to create a clone of the original object. This requires covariant return types, which is tricky with shared/unique pointers. We followed the advice in [this Fluent C++ blog](https://www.fluentcpp.com/2017/09/12/how-to-return-a-smart-pointer-and-use-covariance/). Therefore any new classes should contain a `clone` method (which returns a unique pointer), and a `clone_impl` (which returns a bare pointer) that should only be used by `clone`.

--- a/src/common/include/sirf/common/ImageData.h
+++ b/src/common/include/sirf/common/ImageData.h
@@ -58,6 +58,8 @@ namespace sirf {
         }
         /// Write image to file
         virtual void write(const std::string &filename) const = 0;
+        /// Get a clone of the image as a shared pointer
+        virtual std::shared_ptr<ImageData> clone_as_sptr() const = 0;
 	};
 }
 

--- a/src/common/include/sirf/common/ImageData.h
+++ b/src/common/include/sirf/common/ImageData.h
@@ -58,8 +58,14 @@ namespace sirf {
         }
         /// Write image to file
         virtual void write(const std::string &filename) const = 0;
-        /// Get a clone of the image as a shared pointer
-        virtual std::shared_ptr<ImageData> clone_as_sptr() const = 0;
+        /// Clone and return as unique pointer.
+        std::unique_ptr<ImageData> clone() const
+        {
+            return std::unique_ptr<ImageData>(this->clone_impl());
+        }
+    protected:
+        /// Clone helper function. Don't use.
+        virtual ImageData* clone_impl() const = 0;
 	};
 }
 

--- a/src/common/include/sirf/common/MRImageData.h
+++ b/src/common/include/sirf/common/MRImageData.h
@@ -10,6 +10,14 @@
 namespace sirf {
 	class MRImageData : public ImageData {
 	public:
+        /// Clone and return as unique pointer.
+        std::unique_ptr<MRImageData> clone() const
+        {
+            return std::unique_ptr<MRImageData>(this->clone_impl());
+        }
+    protected:
+        /// Clone helper function. Don't use.
+        virtual MRImageData* clone_impl() const = 0;
 	};
 }
 

--- a/src/common/include/sirf/common/PETImageData.h
+++ b/src/common/include/sirf/common/PETImageData.h
@@ -8,6 +8,14 @@
 namespace sirf {
 	class PETImageData : public ImageData {
 	public:
+        /// Clone and return as unique pointer.
+        std::unique_ptr<PETImageData> clone() const
+        {
+            return std::unique_ptr<PETImageData>(this->clone_impl());
+        }
+    protected:
+        /// Clone helper function. Don't use.
+        virtual PETImageData* clone_impl() const = 0;
 	};
 }
 

--- a/src/xGadgetron/cGadgetron/gadgetron_data_containers.cpp
+++ b/src/xGadgetron/cGadgetron/gadgetron_data_containers.cpp
@@ -1072,6 +1072,16 @@ GadgetronImageData::set_real_data(const float* z)
 }
 
 GadgetronImagesVector::GadgetronImagesVector
+(const GadgetronImagesVector& images) :
+images_(), nimages_(0)
+{
+	for (unsigned int i = 0; i < images.number(); i++) {
+		const ImageWrap& u = images.image_wrap(i);
+		append(u);
+	}
+}
+
+GadgetronImagesVector::GadgetronImagesVector
 (GadgetronImagesVector& images, const char* attr, const char* target) : 
 images_(), nimages_(0)
 {

--- a/src/xGadgetron/cGadgetron/include/sirf/cGadgetron/gadgetron_data_containers.h
+++ b/src/xGadgetron/cGadgetron/include/sirf/cGadgetron/gadgetron_data_containers.h
@@ -716,12 +716,6 @@ namespace sirf {
 			return gadgetron::shared_ptr<GadgetronImageData>
 				(new GadgetronImagesVector(*this, attr, target));
 		}
-        /// Get a clone of the image as a shared pointer
-        virtual std::shared_ptr<ImageData> clone_as_sptr() const
-        {
-            std::shared_ptr<GadgetronImagesVector> im_sptr(new GadgetronImagesVector(*this));
-            return im_sptr;
-        }
 		virtual Iterator& begin()
 		{
 			ImageWrapIter iw = images_.begin();
@@ -759,7 +753,19 @@ namespace sirf {
 		virtual void get_real_data(float* data) const;
 		virtual void set_real_data(const float* data);
 
+        /// Clone and return as unique pointer.
+        std::unique_ptr<GadgetronImagesVector> clone() const
+        {
+            return std::unique_ptr<GadgetronImagesVector>(this->clone_impl());
+        }
+
 	private:
+        /// Clone helper function. Don't use.
+        virtual GadgetronImagesVector* clone_impl() const
+        {
+            return new GadgetronImagesVector(*this);
+        }
+
 		std::vector<gadgetron::shared_ptr<ImageWrap> > images_;
 		int nimages_;
 		mutable gadgetron::shared_ptr<Iterator> begin_;

--- a/src/xGadgetron/cGadgetron/include/sirf/cGadgetron/gadgetron_data_containers.h
+++ b/src/xGadgetron/cGadgetron/include/sirf/cGadgetron/gadgetron_data_containers.h
@@ -641,6 +641,7 @@ namespace sirf {
 
 		GadgetronImagesVector() : images_(), nimages_(0)
 		{}
+        GadgetronImagesVector(const GadgetronImagesVector& images);
 		GadgetronImagesVector(GadgetronImagesVector& images, const char* attr,
 			const char* target);
 		virtual unsigned int items() 
@@ -715,6 +716,12 @@ namespace sirf {
 			return gadgetron::shared_ptr<GadgetronImageData>
 				(new GadgetronImagesVector(*this, attr, target));
 		}
+        /// Get a clone of the image as a shared pointer
+        virtual std::shared_ptr<ImageData> clone_as_sptr() const
+        {
+            std::shared_ptr<GadgetronImagesVector> im_sptr(new GadgetronImagesVector(*this));
+            return im_sptr;
+        }
 		virtual Iterator& begin()
 		{
 			ImageWrapIter iw = images_.begin();

--- a/src/xSTIR/cSTIR/include/sirf/cSTIR/stir_data_containers.h
+++ b/src/xSTIR/cSTIR/include/sirf/cSTIR/stir_data_containers.h
@@ -652,12 +652,6 @@ namespace sirf {
 		}
         /// Write to file
         virtual void write(const std::string &filename) const;
-        /// Get a clone of the image as a shared pointer
-        virtual std::shared_ptr<ImageData> clone_as_sptr() const
-        {
-            std::shared_ptr<STIRImageData> im_sptr(new STIRImageData(*this->data().clone()));
-            return im_sptr;
-        }
 
 		virtual void dot(const DataContainer& a_x, void* ptr);
 		virtual void axpby(
@@ -735,6 +729,19 @@ namespace sirf {
 			_end_const.reset(new Iterator_const(data().end_all()));
 			return *_end_const;
 		}
+
+        /// Clone and return as unique pointer.
+        std::unique_ptr<STIRImageData> clone() const
+        {
+            return std::unique_ptr<STIRImageData>(this->clone_impl());
+        }
+
+    private:
+        /// Clone helper function. Don't use.
+        virtual STIRImageData* clone_impl() const
+        {
+            return new STIRImageData(*this->data().clone());
+        }
 
 	protected:
 		stir::shared_ptr<Image3DF> _data;

--- a/src/xSTIR/cSTIR/include/sirf/cSTIR/stir_data_containers.h
+++ b/src/xSTIR/cSTIR/include/sirf/cSTIR/stir_data_containers.h
@@ -652,6 +652,12 @@ namespace sirf {
 		}
         /// Write to file
         virtual void write(const std::string &filename) const;
+        /// Get a clone of the image as a shared pointer
+        virtual std::shared_ptr<ImageData> clone_as_sptr() const
+        {
+            std::shared_ptr<STIRImageData> im_sptr(new STIRImageData(*this->data().clone()));
+            return im_sptr;
+        }
 
 		virtual void dot(const DataContainer& a_x, void* ptr);
 		virtual void axpby(


### PR DESCRIPTION
We need this so that we can create copies of derived image classes, stored as the base ImageData class. 

We'll need this for registration etc., as the output will be a copy of one of the inputs (which will be stored as the abstract base class, ImageData).