### PR TITLE
Improve MR write images

### DIFF
--- a/examples/Python/MR/fully_sampled_recon.py
+++ b/examples/Python/MR/fully_sampled_recon.py
@@ -11,6 +11,7 @@ Options:
   -p <path>, --path=<path>    path to data files, defaults to data/examples/MR
                               subfolder of SIRF root folder
   -e <engn>, --engine=<engn>  reconstruction engine [default: Gadgetron]
+  -o <outp>, --output=<path>  output file name [default: output.h5]
 '''
 
 ## CCP PETMR Synergistic Image Reconstruction Framework (SIRF).
@@ -82,6 +83,7 @@ def main():
     
     # retrieve reconstruced image data
     image_data = recon.get_output()
+    image_data.write(args['--output'])
 
     # show reconstructed image data
     image_array = image_data.as_array()

--- a/src/xGadgetron/cGadgetron/gadgetron_data_containers.cpp
+++ b/src/xGadgetron/cGadgetron/gadgetron_data_containers.cpp
@@ -38,6 +38,23 @@ using namespace sirf;
 std::string MRAcquisitionData::_storage_scheme;
 shared_ptr<MRAcquisitionData> MRAcquisitionData::acqs_templ_;
 
+static std::string get_date_time_string()
+{
+    time_t rawtime;
+    struct tm * timeinfo;
+    time ( &rawtime );
+    timeinfo = localtime ( &rawtime );
+
+    std::stringstream str;
+    str << timeinfo->tm_year+1900 << "-"
+        << std::setw(2) << std::setfill('0') << timeinfo->tm_mon+1 << "-"
+        << std::setw(2) << std::setfill('0') << timeinfo->tm_mday << " "
+        << std::setw(2) << std::setfill('0') << timeinfo->tm_hour << ":"
+        << std::setw(2) << std::setfill('0') << timeinfo->tm_min << ":"
+        << std::setw(2) << std::setfill('0') << timeinfo->tm_sec;
+    return str.str();
+}
+
 void 
 MRAcquisitionData::write(const char* filename)
 {
@@ -1022,13 +1039,8 @@ GadgetronImageData::write(const std::string &filename, const std::string &groupn
 		return;
     // If the groupname hasn't been set, use the current date and time.
     std::string group = groupname;
-    if (group.empty()) {
-        auto t = std::time(nullptr);
-        auto tm = *std::localtime(&t);
-        std::ostringstream oss;
-        oss << std::put_time(&tm, "%Y-%m-%d_%H-%M-%S");
-        group = oss.str();
-    }
+    if (group.empty())
+        group = get_date_time_string();
 	Mutex mtx;
 	mtx.lock();
 	ISMRMRD::Dataset dataset(filename.c_str(), group.c_str());

--- a/src/xGadgetron/cGadgetron/gadgetron_data_containers.cpp
+++ b/src/xGadgetron/cGadgetron/gadgetron_data_containers.cpp
@@ -27,6 +27,7 @@ limitations under the License.
 \author CCP PETMR
 */
 #include <cmath>
+#include <iomanip>
 
 #include "sirf/cGadgetron/cgadgetron_shared_ptr.h"
 #include "sirf/cGadgetron/gadgetron_data_containers.h"
@@ -1019,9 +1020,18 @@ GadgetronImageData::write(const std::string &filename, const std::string &groupn
 	//if (images_.size() < 1)
 	if (number() < 1)
 		return;
+    // If the groupname hasn't been set, use the current date and time.
+    std::string group = groupname;
+    if (group.empty()) {
+        auto t = std::time(nullptr);
+        auto tm = *std::localtime(&t);
+        std::ostringstream oss;
+        oss << std::put_time(&tm, "%Y-%m-%d_%H-%M-%S");
+        group = oss.str();
+    }
 	Mutex mtx;
 	mtx.lock();
-	ISMRMRD::Dataset dataset(filename.c_str(), groupname.c_str());
+	ISMRMRD::Dataset dataset(filename.c_str(), group.c_str());
 	mtx.unlock();
 	for (unsigned int i = 0; i < number(); i++) {
 		const ImageWrap& iw = image_wrap(i);

--- a/src/xGadgetron/cGadgetron/include/sirf/cGadgetron/gadgetron_data_containers.h
+++ b/src/xGadgetron/cGadgetron/include/sirf/cGadgetron/gadgetron_data_containers.h
@@ -408,7 +408,7 @@ namespace sirf {
 		virtual void set_real_data(const float* data);
 		virtual int read(std::string filename);
 		virtual void write(const std::string &filename, const std::string &groupname) const;
-        virtual void write(const std::string &filename) const { this->write(filename,"dataset"); }
+        virtual void write(const std::string &filename) const { this->write(filename,""); }
 		virtual Dimensions dimensions() const 
 		{
 			Dimensions dim;

--- a/src/xGadgetron/pGadgetron/Gadgetron.py
+++ b/src/xGadgetron/pGadgetron/Gadgetron.py
@@ -537,7 +537,7 @@ class ImageData(SIRF.ImageData):
         return ip.process(self)
     def image(self, im_num):
         return Image(self, im_num)
-    def write(self, out_file, out_group='dataset'):
+    def write(self, out_file, out_group=''):
         '''
         Writes self's images to an hdf5 file.
         out_file : the file name (Python string)


### PR DESCRIPTION
- Save the output when running `fully_sampled_recon.py`
- When saving MR images, use current date and time as default group

The latter point is preferable to current functionality (using 'dataset' by default), as this will not cause accidental concatenation of different reconstructions.