### PR TITLE
Move detection of Boost components to top-level

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 
 #========================================================================
 # Author: Kris Thielemans
-# Copyright 2016 - 2018 University College London
+# Copyright 2016 - 2019 University College London
 # Copyright 2016 - 2018 Science Technology Facilities Council
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
@@ -66,7 +66,14 @@ endif(APPLE)
 
 #### we need the boost library from boost.org
 set(BOOST_ROOT CACHE PATH "root of Boost")
-find_package( Boost 1.36.0 REQUIRED )
+find_package(Boost 1.36.0 COMPONENTS system filesystem thread date_time chrono REQUIRED)
+# For Visual Studio we have to disable the auto-linking feature of boost
+# where just including a boost file automatically adds it to the linker path.
+# Although this sounds great, it sadly breaks because of conflicting file-paths when linking etc etc.
+# In any case, we need to add the libraries by hand for other systems.
+# See http://stackoverflow.com/questions/32252016/cmake-visual-studio-build-looks-for-wrong-library
+add_definitions(-DBOOST_ALL_NO_LIB)
+
 include_directories(${Boost_INCLUDE_DIRS})
 
 #### optional back-ends

--- a/src/xGadgetron/cGadgetron/CMakeLists.txt
+++ b/src/xGadgetron/cGadgetron/CMakeLists.txt
@@ -1,6 +1,7 @@
 #========================================================================
 # Author: Kris Thielemans
-# Copyright 2016, 2017 University College London
+# Copyright 2016, 2017, 2019 University College London
+# Copyright 2018 Science Technology Facilities Council
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
@@ -15,13 +16,14 @@
 #  limitations under the License.
 #
 #=========================================================================
-find_package(Boost COMPONENTS system filesystem thread date_time chrono REQUIRED)
+# Commented out, as this is now done at the top-level
+#find_package(Boost COMPONENTS system filesystem thread date_time chrono REQUIRED)
 # For Visual Studio we have to disable the auto-linking feature of boost
 # where just including a boost file automatically adds it to the linker path.
 # Although this sounds great, it sadly breaks because of conflicting file-paths when linking etc etc.
 # In any case, we need to add the libraries by hand for other systems.
 # See http://stackoverflow.com/questions/32252016/cmake-visual-studio-build-looks-for-wrong-library
-add_definitions(-DBOOST_ALL_NO_LIB)
+#add_definitions(-DBOOST_ALL_NO_LIB)
 
 if (SIRF_INSTALL_DEPENDENCIES AND WIN32)
     set(Boost_DLL_DIR ${Boost_LIBRARY_DIR_RELEASE})

--- a/src/xGadgetron/mGadgetron/CMakeLists.txt
+++ b/src/xGadgetron/mGadgetron/CMakeLists.txt
@@ -17,8 +17,8 @@
 #=========================================================================
 
 if(BUILD_MATLAB)
-
-  find_package(Boost COMPONENTS system thread filesystem REQUIRED)
+  #commented out as done at top-level
+  #find_package(Boost COMPONENTS system thread filesystem REQUIRED)
 
   set(CMAKE_POSITION_INDEPENDENT_CODE True)
 

--- a/src/xSTIR/cSTIR/CMakeLists.txt
+++ b/src/xSTIR/cSTIR/CMakeLists.txt
@@ -1,6 +1,7 @@
 #========================================================================
 # Author: Kris Thielemans
-# Copyright 2016 University College London
+# Copyright 2016 - 2018 University College London
+# Copyright 2017, 2018 Science Technology Facilities Council
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.


### PR DESCRIPTION
This solves a problem that `cstir` didn't properly depend on the Boost
libraries, as it hadn't searched for them. It seems best to search
at top-level in any case.