### PR TITLE
Don't throw error when setting up geom info

### DIFF
--- a/src/common/include/sirf/common/ImageData.h
+++ b/src/common/include/sirf/common/ImageData.h
@@ -1,3 +1,23 @@
+/*
+CCP PETMR Synergistic Image Reconstruction Framework (SIRF)
+Copyright 2018 Rutherford Appleton Laboratory STFC
+Copyright 2018 University College London
+
+This is software developed for the Collaborative Computational
+Project in Positron Emission Tomography and Magnetic Resonance imaging
+(http://www.ccppetmr.ac.uk/).
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
 #pragma once
 
 #ifndef SIRF_ABSTRACT_IMAGE_DATA_TYPE
@@ -67,7 +87,9 @@ namespace sirf {
             // If the geometrical info has not been created yet, throw an error
             if (!_geom_info_sptr)
                 throw std::runtime_error("Geometrical info not initialised. This implies that"
-                                         " your constructor did not call set_up_geom_info().");
+                                         " your constructor did not call set_up_geom_info() or there was "
+                                         "an error. Build in debug mode and lookout for any printed text "
+                                         "containing '::set_up_geom_info()'.");
             return _geom_info_sptr;
         }
         /// Clone and return as unique pointer.

--- a/src/iUtilities/include/sirf/iUtilities/DataHandle.h
+++ b/src/iUtilities/include/sirf/iUtilities/DataHandle.h
@@ -32,6 +32,7 @@ limitations under the License.
 
 #include <stdlib.h>
 #include <string>
+#include <stdexcept>
 
 #include "sirf/iUtilities/LocalisedException.h"
 
@@ -50,6 +51,12 @@ limitations under the License.
 		DataHandle* handle = new DataHandle;\
 		handle->set(0, &status);\
 		return (void*)handle;\
+        }\
+    catch (const std::exception &error) {\
+        ExecutionStatus status(error.what(), __FILE__, __LINE__);\
+        DataHandle* handle = new DataHandle;\
+        handle->set(0, &status);\
+        return (void*)handle;\
         }\
 	catch (...) {\
 		ExecutionStatus status("unhandled", __FILE__, __LINE__);\

--- a/src/xGadgetron/cGadgetron/gadgetron_data_containers.cpp
+++ b/src/xGadgetron/cGadgetron/gadgetron_data_containers.cpp
@@ -1,6 +1,7 @@
 /*
 CCP PETMR Synergistic Image Reconstruction Framework (SIRF)
 Copyright 2015 - 2017 Rutherford Appleton Laboratory STFC
+Copyright 2018 University College London
 
 This is software developed for the Collaborative Computational
 Project in Positron Emission Tomography and Magnetic Resonance imaging
@@ -1189,8 +1190,12 @@ GadgetronImagesVector::set_up_geom_info()
 
         // First check that the slice direction is a unit vector
         const float * const slice_dir = ih1.slice_dir;
-        if (!is_unit_vector(ih1.read_dir) || !is_unit_vector(ih1.phase_dir) || !is_unit_vector(ih1.slice_dir))
-            throw std::runtime_error("GadgetronImagesVector::set_up_geom_info(): read_dir, phase_dir and slice_dir should all be unit vectors.");
+        if (!is_unit_vector(ih1.read_dir) || !is_unit_vector(ih1.phase_dir) || !is_unit_vector(ih1.slice_dir)) {
+#ifndef NDEBUG
+            std::cout << "\nGadgetronImagesVector::set_up_geom_info(): read_dir, phase_dir and slice_dir should all be unit vectors.\n";
+#endif
+            return;
+        }
 
         // Calculate the spacing!
         ISMRMRD::ImageHeader &ih2 = image_wrap(1).head();
@@ -1213,8 +1218,12 @@ GadgetronImagesVector::set_up_geom_info()
 
             // 1. Check that the slice_dir is always constant
             for (int dim=0; dim<3; ++dim)
-                if (std::abs(slice_dir[dim]-ih1.slice_dir[dim]) > 1.e-7F)
-                    throw std::runtime_error("GadgetronImagesVector::set_up_geom_info(): Slice direction alters between different slices. Expected it to be constant.");
+                if (std::abs(slice_dir[dim]-ih1.slice_dir[dim]) > 1.e-7F) {
+#ifndef NDEBUG
+                    std::cout << "\nGadgetronImagesVector::set_up_geom_info(): Slice direction alters between different slices. Expected it to be constant.");
+#endif
+                    return;
+                }
 
             // 2. Check that spacing is constant
             float projection_of_position_in_slice_dir_1 = ih1.position[0] * ih1.slice_dir[0] +
@@ -1224,8 +1233,12 @@ GadgetronImagesVector::set_up_geom_info()
                     ih2.position[1] * ih2.slice_dir[1] +
                     ih2.position[2] * ih2.slice_dir[2];
             float new_spacing = std::abs(projection_of_position_in_slice_dir_1 - projection_of_position_in_slice_dir_2);
-            if (std::abs(spacing[2]-new_spacing) > 1.e-4F)
-                throw std::runtime_error("GadgetronImagesVector::set_up_geom_info(): Slice distances alters between slices. Expected it to be constant.");
+            if (std::abs(spacing[2]-new_spacing) > 1.e-4F) {
+#ifndef NDEBUG
+                std::cout << "\nGadgetronImagesVector::set_up_geom_info(): Slice distances alters between slices. Expected it to be constant.");
+#endif
+                return;
+            }
         }
     }
 

--- a/src/xSTIR/cSTIR/stir_data_containers.cpp
+++ b/src/xSTIR/cSTIR/stir_data_containers.cpp
@@ -1,6 +1,7 @@
 /*
 CCP PETMR Synergistic Image Reconstruction Framework (SIRF)
 Copyright 2015 - 2017 Rutherford Appleton Laboratory STFC
+Copyright 2018 University College London
 
 This is software developed for the Collaborative Computational
 Project in Positron Emission Tomography and Magnetic Resonance imaging


### PR DESCRIPTION
Setting up geom info is only important when converting to different file types (which we don't do very often). 

Therefore, we shouldn't throw an error if we can't set it up for any reason (e.g., metadata missing). Instead, print a message when in debug mode.

Also:
- Handle std exceptions
- updated copyrights