### PR TITLE
Add getter for number of total voxels to NiftiImageData

### DIFF
--- a/src/Registration/cReg/NiftiImageData.cpp
+++ b/src/Registration/cReg/NiftiImageData.cpp
@@ -364,6 +364,12 @@ const int* NiftiImageData<dataType>::get_dimensions() const
 }
 
 template<class dataType>
+size_t NiftiImageData<dataType>::get_num_voxels() const
+{
+    return _nifti_image->nvox;
+}
+
+template<class dataType>
 void NiftiImageData<dataType>::check_dimensions(const NiftiImageDataType image_type)
 {
     if (!this->is_initialised())

--- a/src/Registration/cReg/include/sirf/cReg/NiftiImageData.h
+++ b/src/Registration/cReg/include/sirf/cReg/NiftiImageData.h
@@ -272,8 +272,11 @@ public:
     /// Get norm
     float get_norm(const NiftiImageData&) const;
 
-    /// Get number of voxels
+    /// Get data size in each dimension
     const int* get_dimensions() const;
+
+    /// Get total number of voxels
+    size_t get_num_voxels() const;
 
     /// Print header info
     void print_header() const;


### PR DESCRIPTION
This function is useful to loop over the elements.
