### PR TITLE
add import sirf.Utilities to tests and minor clean-up

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -195,7 +195,7 @@ before_install:
  # setuptools may be out of date on osx
  - $PY_EXE -m pip install --user -U pip setuptools wheel
  # ensure python bin dir exists (and coverage dependencies installed)
- - $PY_EXE -m pip install --user -U nose codecov coveralls
+ - $PY_EXE -m pip install --user -U nose codecov coveralls requests
  # for counting clones, excluding ours
  - |
     if [[ -n "$GITHUB_API_TOKEN" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -247,11 +247,7 @@ script:
  - echo "----------- Last 200 lines of gadgetron.log"
  - tail -n 200 gadgetron.log
 
-
-
-
-
 after_success:
- - cd SIRF
+ - cd sources/SIRF
  - codecov
  - coveralls

--- a/src/xGadgetron/pGadgetron/tests/CMakeLists.txt
+++ b/src/xGadgetron/pGadgetron/tests/CMakeLists.txt
@@ -21,5 +21,5 @@
 #
 #=========================================================================
 add_test(NAME MR_TESTS_PYTHON
-  COMMAND ${PYTHON_EXECUTABLE} -m nose --with-coverage --cover-package=pGadgetron src/xGadgetron/pGadgetron/
+  COMMAND ${PYTHON_EXECUTABLE} -m nose --with-coverage --cover-package=sirf.Gadgetron src/xGadgetron/pGadgetron/
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})

--- a/src/xGadgetron/pGadgetron/tests/test1.py
+++ b/src/xGadgetron/pGadgetron/tests/test1.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-"""Test set 1.
+"""sirf.Gadgetron Test set 1.
 v{version}
 
 Fully sampled data tests
@@ -15,9 +15,10 @@ Options:
 
 {licence}
 """
-from pGadgetron import *
 # Created on Tue Nov 21 10:17:28 2017
-__version__ = "0.2.0"
+from sirf.Gadgetron import *
+from sirf.Utilities import runner, RE_PYEXT, __license__
+__version__ = "0.2.3"
 __author__ = "Evgueni Ovtchinnikov, Casper da Costa-Luis"
 
 

--- a/src/xGadgetron/pGadgetron/tests/test2.py
+++ b/src/xGadgetron/pGadgetron/tests/test2.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-"""Test set 2.
+"""sirf.Gadgetron test set 2.
 v{version}
 
 Undersampled data tests
@@ -15,9 +15,10 @@ Options:
 
 {licence}
 """
-from pGadgetron import *
 # Created on Tue Nov 21 11:23:39 2017
-__version__ = "0.2.0"
+from sirf.Gadgetron import *
+from sirf.Utilities import runner, RE_PYEXT, __license__
+__version__ = "0.2.3"
 __author__ = "Evgueni Ovtchinnikov, Casper da Costa-Luis"
 
 

--- a/src/xGadgetron/pGadgetron/tests/test3.py
+++ b/src/xGadgetron/pGadgetron/tests/test3.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-"""Test set 3.
+"""sirf.Gadgetron set 3.
 v{version}
 
 Fully sampled data tests
@@ -15,11 +15,12 @@ Options:
 
 {licence}
 """
-from pGadgetron import *
 import math
 # Created on Tue Nov 21 10:17:28 2017
-__version__ = "0.2.0"
-__author__ = "Casper da Costa-Luis"
+from sirf.Gadgetron import *
+from sirf.Utilities import runner, RE_PYEXT, __license__
+__version__ = "0.2.3"
+__author__ = "Evgueni Ovtchinnikov, Casper da Costa-Luis"
 
 
 def test_main(rec=False, verb=False, throw=True):

--- a/src/xSTIR/pSTIR/tests/CMakeLists.txt
+++ b/src/xSTIR/pSTIR/tests/CMakeLists.txt
@@ -21,5 +21,5 @@
 #
 #=========================================================================
 add_test(NAME PET_TESTS_PYTHON
-  COMMAND ${PYTHON_EXECUTABLE} -m nose --with-coverage --cover-package=pSTIR src/xSTIR/pSTIR/
+  COMMAND ${PYTHON_EXECUTABLE} -m nose --with-coverage --cover-package=sirf.STIR src/xSTIR/pSTIR/
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})

--- a/src/xSTIR/pSTIR/tests/tests_four.py
+++ b/src/xSTIR/pSTIR/tests/tests_four.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-"""pSTIR Acquisitions and images algebra tests
+"""sirf.STIR Acquisitions and images algebra tests
 v{version}
 
 Usage:
@@ -14,9 +14,10 @@ Options:
 {licence}
 """
 import math
-from pSTIR import *
-__version__ = "0.2.2"
-__author__ = "Casper da Costa-Luis"
+from sirf.STIR import *
+from sirf.Utilities import runner, RE_PYEXT, __license__
+__version__ = "0.2.3"
+__author__ = "Evgueni Ovtchinnikov, Casper da Costa-Luis"
 
 
 def test_main(rec=False, verb=False, throw=True):

--- a/src/xSTIR/pSTIR/tests/tests_one.py
+++ b/src/xSTIR/pSTIR/tests/tests_one.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-"""pSTIR tests
+"""sirf.STIR tests
 v{version}
 
 Usage:
@@ -14,9 +14,10 @@ Options:
 {licence}
 """
 import math
-from pSTIR import *
-__version__ = "0.2.2"
-__author__ = "Casper da Costa-Luis"
+from sirf.STIR import *
+from sirf.Utilities import runner, RE_PYEXT, __license__
+__version__ = "0.2.3"
+__author__ = "Evgueni Ovtchinnikov, Casper da Costa-Luis"
 
 
 def norm(v):

--- a/src/xSTIR/pSTIR/tests/tests_three.py
+++ b/src/xSTIR/pSTIR/tests/tests_three.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-"""pSTIR OSSPS reconstruction tests
+"""sirf.STIR OSSPS reconstruction tests
 v{version}
 
 Usage:
@@ -13,9 +13,10 @@ Options:
 
 {licence}
 """
-from pSTIR import *
-__version__ = "0.2.2"
-__author__ = "Casper da Costa-Luis"
+from sirf.STIR import *
+from sirf.Utilities import runner, RE_PYEXT, __license__
+__version__ = "0.2.3"
+__author__ = "Evgueni Ovtchinnikov, Casper da Costa-Luis"
 
 
 def test_main(rec=False, verb=False, throw=True):

--- a/src/xSTIR/pSTIR/tests/tests_two.py
+++ b/src/xSTIR/pSTIR/tests/tests_two.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-"""pSTIR OSEM reconstruction tests
+"""sirf.STIR OSEM reconstruction tests
 v{version}
 
 Usage:
@@ -14,10 +14,10 @@ Options:
 {licence}
 """
 import math
-from pSTIR import *
-__version__ = "0.2.2"
-__author__ = "Casper da Costa-Luis"
-
+from sirf.STIR import *
+from sirf.Utilities import runner, RE_PYEXT, __license__
+__version__ = "0.2.3"
+__author__ = "Evgueni Ovtchinnikov, Casper da Costa-Luis"
 
 def test_main(rec=False, verb=False, throw=True):
     datafile = RE_PYEXT.sub(".txt", __file__)


### PR DESCRIPTION
- import sirf.Utilities Was missing which led to errors of
missing `runner` when run on its own. Fixes #317.
- replace pSTIR with sirf.STIR etc
- fix author list