### PR TITLE
fix coverage paths

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -248,6 +248,8 @@ script:
  - tail -n 200 gadgetron.log
 
 after_success:
- - cd sources/SIRF
+ - pushd sources/SIRF/
+ - sed -ir 's/SIRF-SuperBuild\/INSTALL\/python\/sirf\/(\w*\.py)/\1/g' .coverage
  - codecov
  - coveralls
+ - popd

--- a/.travis.yml
+++ b/.travis.yml
@@ -248,8 +248,8 @@ script:
  - tail -n 200 gadgetron.log
 
 after_success:
- - pushd sources/SIRF/
- - sed -ir 's/SIRF-SuperBuild\/INSTALL\/python\/sirf\/(\w*\.py)/\1/g' .coverage
+ - pushd ../SIRF
+ - sed -r 's/SIRF-SuperBuild\/INSTALL\/python\/sirf\/(\w*)\.py/SIRF\/src\/x\1\/p\1\/\1.py/g' ../SIRF-SuperBuild/sources/SIRF/.coverage > .coverage
  - codecov
  - coveralls
  - popd


### PR DESCRIPTION
fixes #320 Coverage being reported for installed files (which have different paths to source files).

- [ ] or can go back to running tests from sources/SIRF rather than INSTALL/python?
- [x] or could find&replace paths in the generated coverage reports before uploading?

info:

- https://bitbucket.org/ned/coveragepy/pull-requests/70/set-base-directory-for-relative-filenames/activity# (mentioning [paths]).
- lemurheavy/coveralls-public#263