### PR TITLE
Data handle vector

### DIFF
--- a/src/Registration/cReg/cReg.cpp
+++ b/src/Registration/cReg/cReg.cpp
@@ -165,7 +165,6 @@ void* cReg_NiftiImageData_print_headers(const void* handle_vector_ptr)
     try {
         DataHandleVector handle_vector = objectFromHandle<DataHandleVector>(handle_vector_ptr);
         std::vector<const NiftiImageData<float> > vec;
-        if (num_ims >= 2) vec.push_back(objectFromHandle<NiftiImageData<float> >(im2));
         for (unsigned i=0; i<handle_vector.size(); ++i)
             vec.push_back(objectFromHandle<const NiftiImageData<float> >(handle_vector.at(i)));
         std::vector<const NiftiImageData<float>*> vec_ptr;
@@ -467,27 +466,18 @@ void* cReg_NiftiImageData3DTensor_flip_component(const void *ptr, const int dim)
 // -------------------------------------------------------------------------------- //
 //      NiftiImageData3DDeformation
 // -------------------------------------------------------------------------------- //
-void* cReg_NiftiImageData3DDeformation_compose_single_deformation(const void* im, const int num_elements, const char* types, const void* trans1, const void* trans2, const void* trans3, const void* trans4, const void* trans5)
+void* cReg_NiftiImageData3DDeformation_compose_single_deformation(const void* im, const char* types, const void* trans_vector_ptr)
 {
     try {
         // This is an ugly hack because I can't get virtual methods to work for multiple inherited (NiftiImageData3DDeformation/NiftiImageData3DDisplacement).
         // So, we also give a string which tells us what type they are, and we change the template type of objectFromHandle accordingly.
 
-        // Also, we can't have default arguments in C, so if we only want to compose 3 transformations, set the 4th and 5th as 'None' in Python. In C,
-        // we create a vector from all the non-'None' arguments and then convert them to their derived classes.
-
         // Sorry this is so ugly.
 
         // There's always going to be at least two transformations, so start by putting them in the vector
-        std::vector<const void*> vec = {trans1, trans2};
-        // Add in any extras, depending on the number of transformations
-        if (num_elements >= 3) vec.push_back(trans3);
-        if (num_elements >= 4) vec.push_back(trans4);
-        if (num_elements >= 5) vec.push_back(trans5);
-
-        // Vector for casting to the correct type
+        DataHandleVector vec = objectFromHandle<DataHandleVector>(trans_vector_ptr);
         std::vector<const Transformation<float> *> trans_vec;
-        for (int i=0; i<num_elements; ++i)
+        for (unsigned i=0; i<vec.size(); ++i)
             if      (types[i] == '1')
                 trans_vec.push_back(&objectFromHandle<const AffineTransformation<float> >(vec.at(i)));
             else if (types[i] == '2')

--- a/src/Registration/cReg/cReg.cpp
+++ b/src/Registration/cReg/cReg.cpp
@@ -160,17 +160,16 @@ void* cReg_objectFromFile(const char* name, const char* filename)
 //      NiftiImageData
 // -------------------------------------------------------------------------------- //
 extern "C"
-void* cReg_NiftiImageData_print_headers(const int num_ims, const void* im1, const void* im2, const void* im3, const void* im4, const void* im5)
+void* cReg_NiftiImageData_print_headers(const void* handle_vector_ptr)
 {
     try {
-        std::vector<NiftiImageData<float> > vec;
-        if (num_ims >= 1) vec.push_back(objectFromHandle<NiftiImageData<float> >(im1));
+        DataHandleVector handle_vector = objectFromHandle<DataHandleVector>(handle_vector_ptr);
+        std::vector<const NiftiImageData<float> > vec;
         if (num_ims >= 2) vec.push_back(objectFromHandle<NiftiImageData<float> >(im2));
-        if (num_ims >= 3) vec.push_back(objectFromHandle<NiftiImageData<float> >(im3));
-        if (num_ims >= 4) vec.push_back(objectFromHandle<NiftiImageData<float> >(im4));
-        if (num_ims >= 5) vec.push_back(objectFromHandle<NiftiImageData<float> >(im5));
+        for (unsigned i=0; i<handle_vector.size(); ++i)
+            vec.push_back(objectFromHandle<const NiftiImageData<float> >(handle_vector.at(i)));
         std::vector<const NiftiImageData<float>*> vec_ptr;
-        for (int i=0; i<vec.size(); ++i)
+        for (unsigned i=0; i<vec.size(); ++i)
             vec_ptr.push_back(&vec[i]);
         NiftiImageData<float>::print_headers(vec_ptr);
         return new DataHandle;

--- a/src/Registration/cReg/cReg.cpp
+++ b/src/Registration/cReg/cReg.cpp
@@ -163,14 +163,11 @@ extern "C"
 void* cReg_NiftiImageData_print_headers(const void* handle_vector_ptr)
 {
     try {
-        DataHandleVector handle_vector = objectFromHandle<DataHandleVector>(handle_vector_ptr);
-        std::vector<const NiftiImageData<float> > vec;
+        const DataHandleVector handle_vector = objectFromHandle<const DataHandleVector>(handle_vector_ptr);
+        std::vector<const NiftiImageData<float>*> vec;
         for (unsigned i=0; i<handle_vector.size(); ++i)
-            vec.push_back(objectFromHandle<const NiftiImageData<float> >(handle_vector.at(i)));
-        std::vector<const NiftiImageData<float>*> vec_ptr;
-        for (unsigned i=0; i<vec.size(); ++i)
-            vec_ptr.push_back(&vec[i]);
-        NiftiImageData<float>::print_headers(vec_ptr);
+            vec.push_back(&objectFromHandle<const NiftiImageData<float> >(handle_vector.at(i)));
+        NiftiImageData<float>::print_headers(vec);
         return new DataHandle;
     }
     CATCH;
@@ -475,7 +472,7 @@ void* cReg_NiftiImageData3DDeformation_compose_single_deformation(const void* im
         // Sorry this is so ugly.
 
         // There's always going to be at least two transformations, so start by putting them in the vector
-        DataHandleVector vec = objectFromHandle<DataHandleVector>(trans_vector_ptr);
+        const DataHandleVector vec = objectFromHandle<const DataHandleVector>(trans_vector_ptr);
         std::vector<const Transformation<float> *> trans_vec;
         for (unsigned i=0; i<vec.size(); ++i)
             if      (types[i] == '1')

--- a/src/Registration/cReg/cReg.h
+++ b/src/Registration/cReg/cReg.h
@@ -40,7 +40,7 @@ extern "C" {
     void* cReg_parameter(const void* ptr, const char* obj, const char* name);
 
     // NiftiImageData
-    void* cReg_NiftiImageData_print_headers(const int num_ims, const void* im1, const void* im2, const void* im3, const void* im4, const void* im5);
+    void* cReg_NiftiImageData_print_headers(const void *handle_vector_ptr);
     void* cReg_NiftiImageData_write(const void* ptr, const char* filename, const int datatype);
     void* cReg_NiftiImageData_fill(const void* ptr, const float val);
     void* cReg_NiftiImageData_fill_arr(const void* ptr, PTR_FLOAT val);

--- a/src/Registration/cReg/cReg.h
+++ b/src/Registration/cReg/cReg.h
@@ -66,7 +66,7 @@ extern "C" {
     void* cReg_NiftiImageData3DTensor_flip_component(const void *ptr, const int dim);
 
     // NiftiImageData3DDeformation
-    void* cReg_NiftiImageData3DDeformation_compose_single_deformation(const void* im, const int num_elements, const char* types, const void* trans1, const void* trans2, const void* trans3, const void* trans4, const void* trans5);
+    void* cReg_NiftiImageData3DDeformation_compose_single_deformation(const void* im, const char* types, const void* trans_vector_ptr);
     void* cReg_NiftiImageData3DDeformation_create_from_disp(const void* disp_ptr);
 
     // NiftiImageData3DDisplacement

--- a/src/Registration/mReg/+sirf/+Reg/NiftiImageData.m
+++ b/src/Registration/mReg/+sirf/+Reg/NiftiImageData.m
@@ -185,7 +185,9 @@ classdef NiftiImageData < sirf.SIRF.ImageData
         end
         function print_header(self)
             %Print metadata of nifti image.
-            h = calllib('mreg', 'mReg_NiftiImageData_print_headers', 1, self.handle_, [], [], [], []);
+            vec = sirf.SIRF.DataHandleVector();
+            vec.push_back(self.handle_)
+            h = calllib('mreg', 'mReg_NiftiImageData_print_headers', vec.handle_);
             sirf.Utilities.check_status('parameter', h)
         end
         function set_voxel_spacing(self,spacing,interpolation_order)
@@ -198,22 +200,13 @@ classdef NiftiImageData < sirf.SIRF.ImageData
     end
     methods(Static)
         function print_headers(to_print)
-            %Print metadata of one or multiple (up to 5) nifti images.
+            %Print metadata of one or multiple nifti images.
             assert(ismatrix(to_print) && isa(to_print, 'sirf.Reg.NiftiImageData'), 'NiftiImageData.print_headers: give list of NiftiImageData.')
-            num_ims = size(to_print,2);
-            if num_ims == 1
-                h = calllib('mreg', 'mReg_NiftiImageData_print_headers', 1, to_print(1).handle_, [], [], [], []);
-            elseif num_ims == 2
-                h = calllib('mreg', 'mReg_NiftiImageData_print_headers', 2, to_print(1).handle_, to_print(2).handle_, [], [], []);
-            elseif num_ims == 3
-                h = calllib('mreg', 'mReg_NiftiImageData_print_headers', 3, to_print(1).handle_, to_print(2).handle_, to_print(3).handle_, [], []);
-            elseif num_ims == 4
-                h = calllib('mreg', 'mReg_NiftiImageData_print_headers', 4, to_print(1).handle_, to_print(2).handle_, to_print(3).handle_, to_print(4).handle_, []);
-            elseif num_ims == 5
-                h = calllib('mreg', 'mReg_NiftiImageData_print_headers', 5, to_print(1).handle_, to_print(2).handle_, to_print(3).handle_, to_print(4).handle_, to_print(5).handle_);
-            else
-                error('print_headers only implemented for up to 5 images.')
+            vec = sirf.SIRF.DataHandleVector();
+            for n = 1:length(to_print)
+                vec.push_back(to_print(n).handle_);
             end
+            h = calllib('mreg', 'mReg_NiftiImageData_print_headers', vec.handle_);
             sirf.Utilities.check_status('parameter', h)
         end
     end

--- a/src/Registration/mReg/+sirf/+Reg/NiftiImageData3DDeformation.m
+++ b/src/Registration/mReg/+sirf/+Reg/NiftiImageData3DDeformation.m
@@ -53,11 +53,7 @@ classdef NiftiImageData3DDeformation < sirf.Reg.NiftiImageData3DTensor & sirf.Re
 	    	%Compose up to transformations into single deformation.
 		    assert(isa(ref, 'sirf.SIRF.ImageData'))
 		    assert(isa(trans, 'sirf.Reg.Transformation'))
-		    if isrow(trans)
-                trans=trans'; 
-            end
-		    assert(iscolumn(trans));
-            num_trans = size(trans,1);
+            num_trans = length(trans);
 		    if num_trans == 1
 		    	z = trans(1).get_as_deformation_field(ref);
 		        return
@@ -75,23 +71,13 @@ classdef NiftiImageData3DDeformation < sirf.Reg.NiftiImageData3DTensor & sirf.Re
                     types = [types '3'];
                 end
             end
-		    z = sirf.Reg.NiftiImageData3DDeformation();
-		    if num_trans == 2
-		        z.handle_ = calllib('mreg', 'mReg_NiftiImageData3DDeformation_compose_single_deformation',...
-		        	ref.handle_, num_trans, types, trans(1).handle_, trans(2).handle_, [], [], []);
-		    elseif num_trans == 3
-		        z.handle_ = calllib('mreg', 'mReg_NiftiImageData3DDeformation_compose_single_deformation',...
-		            ref.handle_, num_trans, types, trans(1).handle_, trans(2).handle_, trans(3).handle_, [], []);
-		    elseif num_trans == 4
-		        z.handle_ = calllib('mreg', 'mReg_NiftiImageData3DDeformation_compose_single_deformation',...
-		            ref.handle_, num_trans, types, trans(1).handle_, trans(2).handle_, trans(3).handle_, trans(4).handle_, []);
-		    elseif num_trans == 5
-		        z.handle_ = calllib('mreg', 'mReg_NiftiImageData3DDeformation_compose_single_deformation',...
-		            ref.handle_, num_trans, types, trans(1).handle_, trans(2).handle_, trans(3).handle_, trans(4).handle_, trans(5).handle_);
-		    else
-		        error('compose_transformations_into_single_deformation only implemented for up to 5 transformations.')
-		    end
-		    sirf.Utilities.check_status('compose_transformations_into_single_deformation', z.handle_);
+            % Convert transformations into SIRF vector
+            vec = sirf.SIRF.DataHandleVector()
+            for n = 1:num_trans
+                vec.push_back(trans(n).handle_);
+            end
+            z = sirf.Reg.NiftiImageData3DDeformation();
+            z.handle_ = calllib('mreg', 'mReg_NiftiImageData3DDeformation_compose_single_deformation',ref.handle_, types, vec.handle_);
 		end
     end
 end

--- a/src/Registration/mReg/mreg.c
+++ b/src/Registration/mReg/mreg.c
@@ -108,8 +108,8 @@ EXPORTED_FUNCTION     void* mReg_NiftiImageData3DTensor_construct_from_3_compone
 EXPORTED_FUNCTION     void* mReg_NiftiImageData3DTensor_flip_component(const void *ptr, const int dim) {
 	return cReg_NiftiImageData3DTensor_flip_component(ptr, dim);
 }
-EXPORTED_FUNCTION     void* mReg_NiftiImageData3DDeformation_compose_single_deformation(const void* im, const int num_elements, const char* types, const void* trans1, const void* trans2, const void* trans3, const void* trans4, const void* trans5) {
-	return cReg_NiftiImageData3DDeformation_compose_single_deformation(im, num_elements, types, trans1, trans2, trans3, trans4, trans5);
+EXPORTED_FUNCTION     void* mReg_NiftiImageData3DDeformation_compose_single_deformation(const void* im, const char* types, const void* trans_vector_ptr) {
+	return cReg_NiftiImageData3DDeformation_compose_single_deformation(im, types, trans_vector_ptr);
 }
 EXPORTED_FUNCTION     void* mReg_NiftiImageData3DDeformation_create_from_disp(const void* disp_ptr) {
 	return cReg_NiftiImageData3DDeformation_create_from_disp(disp_ptr);

--- a/src/Registration/mReg/mreg.c
+++ b/src/Registration/mReg/mreg.c
@@ -48,8 +48,8 @@ EXPORTED_FUNCTION     void* mReg_setParameter(void* ptr, const char* obj, const 
 EXPORTED_FUNCTION     void* mReg_parameter(const void* ptr, const char* obj, const char* name) {
 	return cReg_parameter(ptr, obj, name);
 }
-EXPORTED_FUNCTION     void* mReg_NiftiImageData_print_headers(const int num_ims, const void* im1, const void* im2, const void* im3, const void* im4, const void* im5) {
-	return cReg_NiftiImageData_print_headers(num_ims, im1, im2, im3, im4, im5);
+EXPORTED_FUNCTION     void* mReg_NiftiImageData_print_headers(const void *handle_vector_ptr) {
+	return cReg_NiftiImageData_print_headers(handle_vector_ptr);
 }
 EXPORTED_FUNCTION     void* mReg_NiftiImageData_write(const void* ptr, const char* filename, const int datatype) {
 	return cReg_NiftiImageData_write(ptr, filename, datatype);

--- a/src/Registration/mReg/mreg.h
+++ b/src/Registration/mReg/mreg.h
@@ -59,7 +59,7 @@ EXPORTED_FUNCTION     void* mReg_NiftiImageData3DTensor_write_split_xyz_componen
 EXPORTED_FUNCTION     void* mReg_NiftiImageData3DTensor_create_from_3D_image(const void *ptr, const void* obj);
 EXPORTED_FUNCTION     void* mReg_NiftiImageData3DTensor_construct_from_3_components(const char* obj, const void *x_ptr, const void *y_ptr, const void *z_ptr);
 EXPORTED_FUNCTION     void* mReg_NiftiImageData3DTensor_flip_component(const void *ptr, const int dim);
-EXPORTED_FUNCTION     void* mReg_NiftiImageData3DDeformation_compose_single_deformation(const void* im, const int num_elements, const char* types, const void* trans1, const void* trans2, const void* trans3, const void* trans4, const void* trans5);
+EXPORTED_FUNCTION     void* mReg_NiftiImageData3DDeformation_compose_single_deformation(const void* im, const char* types, const void* trans_vector_ptr);
 EXPORTED_FUNCTION     void* mReg_NiftiImageData3DDeformation_create_from_disp(const void* disp_ptr);
 EXPORTED_FUNCTION     void* mReg_NiftiImageData3DDisplacement_create_from_def(const void* def_ptr);
 EXPORTED_FUNCTION     void* mReg_Registration_process(void* ptr);

--- a/src/Registration/mReg/mreg.h
+++ b/src/Registration/mReg/mreg.h
@@ -39,7 +39,7 @@ EXPORTED_FUNCTION  void* mReg_newObject(const char* name);
 EXPORTED_FUNCTION     void* mReg_objectFromFile(const char* name, const char* filename);
 EXPORTED_FUNCTION     void* mReg_setParameter(void* ptr, const char* obj, const char* name, const void* value);
 EXPORTED_FUNCTION     void* mReg_parameter(const void* ptr, const char* obj, const char* name);
-EXPORTED_FUNCTION     void* mReg_NiftiImageData_print_headers(const int num_ims, const void* im1, const void* im2, const void* im3, const void* im4, const void* im5);
+EXPORTED_FUNCTION     void* mReg_NiftiImageData_print_headers(const void *handle_vector_ptr);
 EXPORTED_FUNCTION     void* mReg_NiftiImageData_write(const void* ptr, const char* filename, const int datatype);
 EXPORTED_FUNCTION     void* mReg_NiftiImageData_fill(const void* ptr, const float val);
 EXPORTED_FUNCTION     void* mReg_NiftiImageData_fill_arr(const void* ptr, PTR_FLOAT val);

--- a/src/Registration/pReg/Reg.py
+++ b/src/Registration/pReg/Reg.py
@@ -541,21 +541,13 @@ class NiftiImageData3DDeformation(NiftiImageData3DTensor, _Transformation):
                 types += '2'
             elif isinstance(n, NiftiImageData3DDeformation):
                 types += '3'
+        # Convert transformations into SIRF vector
+        vec = SIRF.DataHandleVector()
+        for n in trans:
+            vec.push_back(n.handle)
         z = NiftiImageData3DDeformation()
-        if len(trans) == 2:
-            z.handle = pyreg.cReg_NiftiImageData3DDeformation_compose_single_deformation(
-                ref.handle, len(trans), types, trans[0].handle, trans[1].handle, None, None, None)
-        elif len(trans) == 3:
-            z.handle = pyreg.cReg_NiftiImageData3DDeformation_compose_single_deformation(
-                ref.handle, len(trans), types, trans[0].handle, trans[1].handle, trans[2].handle, None, None)
-        elif len(trans) == 4:
-            z.handle = pyreg.cReg_NiftiImageData3DDeformation_compose_single_deformation(
-                ref.handle, len(trans), types, trans[0].handle, trans[1].handle, trans[2].handle, trans[3].handle, None)
-        elif len(trans) == 5:
-            z.handle = pyreg.cReg_NiftiImageData3DDeformation_compose_single_deformation(
-                ref.handle, len(trans), types, trans[0].handle, trans[1].handle, trans[2].handle, trans[3].handle, trans[4].handle)
-        else:
-            raise error('compose_single_deformation only implemented for up to 5 transformations.')
+        z.handle = pyreg.cReg_NiftiImageData3DDeformation_compose_single_deformation(
+            ref.handle, types, vec.handle)
         check_status(z.handle)
         return z
 

--- a/src/Registration/pReg/Reg.py
+++ b/src/Registration/pReg/Reg.py
@@ -368,7 +368,9 @@ class NiftiImageData(SIRF.ImageData):
 
     def print_header(self):
         """Print nifti header metadata."""
-        try_calling(pyreg.cReg_NiftiImageData_print_headers(1, self.handle, None, None, None, None))
+        vec = SIRF.DataHandleVector()
+        vec.push_back(self.handle)
+        try_calling(pyreg.cReg_NiftiImageData_print_headers(vec.handle))
 
     def same_object(self):
         """See DataContainer.same_object()."""
@@ -384,26 +386,13 @@ class NiftiImageData(SIRF.ImageData):
 
     @staticmethod
     def print_headers(to_print):
-        """Print nifti header metadata of one or multiple (up to 5) nifti images."""
+        """Print nifti header metadata of one or multiple nifti images."""
         if not all(isinstance(n, NiftiImageData) for n in to_print):
             raise AssertionError()
-        if len(to_print) == 1:
-            try_calling(pyreg.cReg_NiftiImageData_print_headers(
-                1, to_print[0].handle, None, None, None, None))
-        elif len(to_print) == 2:
-            try_calling(pyreg.cReg_NiftiImageData_print_headers(
-                2, to_print[0].handle, to_print[1].handle, None, None, None))
-        elif len(to_print) == 3:
-            try_calling(pyreg.cReg_NiftiImageData_print_headers(
-                3, to_print[0].handle, to_print[1].handle, to_print[2].handle, None, None))
-        elif len(to_print) == 4:
-            try_calling(pyreg.cReg_NiftiImageData_print_headers(
-                4, to_print[0].handle, to_print[1].handle, to_print[2].handle, to_print[3].handle, None))
-        elif len(to_print) == 5:
-            try_calling(pyreg.cReg_NiftiImageData_print_headers(
-                5, to_print[0].handle, to_print[1].handle, to_print[2].handle, to_print[3].handle, to_print[4].handle))
-        else:
-            raise error('print_headers only implemented for up to 5 images.')
+        vec = SIRF.DataHandleVector()
+        for n in to_print:
+            vec.push_back(n.handle)
+        try_calling(pyreg.cReg_NiftiImageData_print_headers(vec.handle))
 
 
 class NiftiImageData3D(NiftiImageData):

--- a/src/common/+sirf/+SIRF/DataHandleVector.m
+++ b/src/common/+sirf/+SIRF/DataHandleVector.m
@@ -1,0 +1,49 @@
+classdef DataHandleVector < handle
+% INTERNAL USE ONLY.
+% Class for an abstract data container.
+
+% CCP PETMR Synergistic Image Reconstruction Framework (SIRF).
+% Copyright 2019 University College London
+% 
+% This is software developed for the Collaborative Computational
+% Project in Positron Emission Tomography and Magnetic Resonance imaging
+% (http://www.ccppetmr.ac.uk/).
+% 
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+% http://www.apache.org/licenses/LICENSE-2.0
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+
+
+    properties
+        name
+        handle_
+    end
+    methods(Static)
+        function name = class_name()
+            name = 'DataHandleVector';
+        end
+    end
+    methods
+        function self = DataHandleVector()
+            self.name = 'DataHandleVector';
+            self.handle_ = calllib('msirf', 'mSIRF_newObject', self.name);
+            sirf.Utilities.check_status(self.name, self.handle_);
+        end
+        function delete(self)
+            if ~isempty(self.handle_)
+                sirf.Utilities.delete(self.handle_)
+                self.handle_ = [];
+            end
+        end
+        function push_back(self,handle_)
+        	%Push back new data handle.
+        	calllib('msirf', 'mSIRF_DataHandleVector_push_back', self.handle_, handle_);
+        end
+    end
+end

--- a/src/common/SIRF.py
+++ b/src/common/SIRF.py
@@ -231,3 +231,21 @@ class DataContainer(ABC):
 
 class ImageData(DataContainer):
     pass
+
+class DataHandleVector:
+    """
+    DataHandle vector.
+    """
+    def __init__(self):
+        self.name = 'DataHandleVector'
+        self.handle = pysirf.cSIRF_newObject(self.name)
+        check_status(self.handle)
+
+    def __del__(self):
+        if self.handle is not None:
+            pyiutil.deleteDataHandle(self.handle)
+
+    def push_back(self, handle):
+        """Push back new data handle."""
+        try_calling(pysirf.cSIRF_DataHandleVector_push_back(self.handle, handle))
+        check_status(self.handle)

--- a/src/common/csirf.cpp
+++ b/src/common/csirf.cpp
@@ -34,6 +34,34 @@ using namespace sirf;
 #define SPTR_FROM_HANDLE(Object, X, H) \
 	shared_ptr<Object> X; getObjectSptrFromHandle<Object>(H, X);
 
+
+static void*
+unknownObject(const char* obj, const char* name, const char* file, int line)
+{
+	DataHandle* handle = new DataHandle;
+	std::string error = "unknown ";
+	error += obj;
+	error += " '";
+	error += name;
+	error += "'";
+	ExecutionStatus status(error.c_str(), file, line);
+	handle->set(0, &status);
+	return (void*)handle;
+}
+
+//default constructors
+extern "C"
+void* cSIRF_newObject(const char* name)
+{
+	try {
+        if (strcmp(name, "DataHandleVector") == 0)
+            return newObjectHandle(std::shared_ptr<DataHandleVector>(new DataHandleVector));
+		return unknownObject("object", name, __FILE__, __LINE__);
+	}
+	CATCH;
+}
+
+
 extern "C"
 void*
 cSIRF_dataItems(const void* ptr_x)
@@ -163,4 +191,13 @@ cSIRF_clone(void* ptr_x)
 		return newObjectHandle(sptr);
 	}
 	CATCH;
+}
+
+extern "C"
+void*
+cSIRF_DataHandleVector_push_back(void* self, const void* to_append)
+{
+    DataHandleVector& vec = objectFromHandle<DataHandleVector>(self);
+    vec.push_back(to_append);
+    return new DataHandle;
 }

--- a/src/common/csirf.cpp
+++ b/src/common/csirf.cpp
@@ -195,7 +195,7 @@ cSIRF_clone(void* ptr_x)
 
 extern "C"
 void*
-cSIRF_DataHandleVector_push_back(void* self, const void* to_append)
+cSIRF_DataHandleVector_push_back(void* self, void* to_append)
 {
     DataHandleVector& vec = objectFromHandle<DataHandleVector>(self);
     vec.push_back(to_append);

--- a/src/common/csirf.h
+++ b/src/common/csirf.h
@@ -32,6 +32,9 @@ extern "C" {
 #define PTR_DOUBLE double*
 #endif
 
+// New SIRF objects
+void* cSIRF_newObject(const char* name);
+
 // Data container methods
 void* cSIRF_dataItems(const void* ptr_x);
 void* cSIRF_norm(const void* ptr_x);
@@ -42,6 +45,9 @@ void* cSIRF_multiply(const void* ptr_x, const void* ptr_y);
 void* cSIRF_divide(const void* ptr_x, const void* ptr_y);
 void* cSIRF_write(const void* ptr, const char* filename);
 void* cSIRF_clone(void* ptr_x);
+
+// DataHandleVector methods
+void* cSIRF_DataHandleVector_push_back(void* self, const void* to_append);
 
 #ifndef CSIRF_FOR_MATLAB
 }

--- a/src/common/csirf.h
+++ b/src/common/csirf.h
@@ -47,7 +47,7 @@ void* cSIRF_write(const void* ptr, const char* filename);
 void* cSIRF_clone(void* ptr_x);
 
 // DataHandleVector methods
-void* cSIRF_DataHandleVector_push_back(void* self, const void* to_append);
+void* cSIRF_DataHandleVector_push_back(void* self, void* to_append);
 
 #ifndef CSIRF_FOR_MATLAB
 }

--- a/src/common/msirf.c
+++ b/src/common/msirf.c
@@ -36,7 +36,10 @@ limitations under the License.
 #define PTR_FLOAT float*
 #define PTR_DOUBLE double*
 #endif
-EXPORTED_FUNCTION  void* mSIRF_dataItems(const void* ptr_x) {
+EXPORTED_FUNCTION  void* mSIRF_newObject(const char* name) {
+	return cSIRF_newObject(name);
+}
+EXPORTED_FUNCTION void* mSIRF_dataItems(const void* ptr_x) {
 	return cSIRF_dataItems(ptr_x);
 }
 EXPORTED_FUNCTION void* mSIRF_norm(const void* ptr_x) {
@@ -59,6 +62,9 @@ EXPORTED_FUNCTION void* mSIRF_write(const void* ptr, const char* filename) {
 }
 EXPORTED_FUNCTION void* mSIRF_clone(void* ptr_x) {
 	return cSIRF_clone(ptr_x);
+}
+EXPORTED_FUNCTION void* mSIRF_DataHandleVector_push_back(void* self, const void* to_append) {
+	return cSIRF_DataHandleVector_push_back(self, to_append);
 }
 #ifndef CSIRF_FOR_MATLAB
 }

--- a/src/common/msirf.c
+++ b/src/common/msirf.c
@@ -63,7 +63,7 @@ EXPORTED_FUNCTION void* mSIRF_write(const void* ptr, const char* filename) {
 EXPORTED_FUNCTION void* mSIRF_clone(void* ptr_x) {
 	return cSIRF_clone(ptr_x);
 }
-EXPORTED_FUNCTION void* mSIRF_DataHandleVector_push_back(void* self, const void* to_append) {
+EXPORTED_FUNCTION void* mSIRF_DataHandleVector_push_back(void* self, void* to_append) {
 	return cSIRF_DataHandleVector_push_back(self, to_append);
 }
 #ifndef CSIRF_FOR_MATLAB

--- a/src/common/msirf.h
+++ b/src/common/msirf.h
@@ -44,7 +44,7 @@ EXPORTED_FUNCTION void* mSIRF_multiply(const void* ptr_x, const void* ptr_y);
 EXPORTED_FUNCTION void* mSIRF_divide(const void* ptr_x, const void* ptr_y);
 EXPORTED_FUNCTION void* mSIRF_write(const void* ptr, const char* filename);
 EXPORTED_FUNCTION void* mSIRF_clone(void* ptr_x);
-EXPORTED_FUNCTION void* mSIRF_DataHandleVector_push_back(void* self, const void* to_append);
+EXPORTED_FUNCTION void* mSIRF_DataHandleVector_push_back(void* self, void* to_append);
 #ifndef CSIRF_FOR_MATLAB
 }
 #endif

--- a/src/common/msirf.h
+++ b/src/common/msirf.h
@@ -35,7 +35,8 @@ limitations under the License.
 #define PTR_FLOAT float*
 #define PTR_DOUBLE double*
 #endif
-EXPORTED_FUNCTION  void* mSIRF_dataItems(const void* ptr_x);
+EXPORTED_FUNCTION  void* mSIRF_newObject(const char* name);
+EXPORTED_FUNCTION void* mSIRF_dataItems(const void* ptr_x);
 EXPORTED_FUNCTION void* mSIRF_norm(const void* ptr_x);
 EXPORTED_FUNCTION void*	mSIRF_dot(const void* ptr_x, const void* ptr_y);
 EXPORTED_FUNCTION void* mSIRF_axpby(const PTR_FLOAT ptr_a, const void* ptr_x, const PTR_FLOAT ptr_b, const void* ptr_y);
@@ -43,6 +44,7 @@ EXPORTED_FUNCTION void* mSIRF_multiply(const void* ptr_x, const void* ptr_y);
 EXPORTED_FUNCTION void* mSIRF_divide(const void* ptr_x, const void* ptr_y);
 EXPORTED_FUNCTION void* mSIRF_write(const void* ptr, const char* filename);
 EXPORTED_FUNCTION void* mSIRF_clone(void* ptr_x);
+EXPORTED_FUNCTION void* mSIRF_DataHandleVector_push_back(void* self, const void* to_append);
 #ifndef CSIRF_FOR_MATLAB
 }
 #endif

--- a/src/iUtilities/include/sirf/iUtilities/DataHandle.h
+++ b/src/iUtilities/include/sirf/iUtilities/DataHandle.h
@@ -32,6 +32,7 @@ limitations under the License.
 
 #include <stdlib.h>
 #include <string>
+#include <vector>
 
 #include "sirf/iUtilities/LocalisedException.h"
 
@@ -63,6 +64,9 @@ limitations under the License.
 		handle->set(0, &status);\
 		return (void*)handle;\
 				}\
+
+/// Typedef of vector of void pointers for a vector of handles
+typedef std::vector<const void *> DataHandleVector;
 
 /*!
 \ingroup C Interface to C++ Objects

--- a/src/iUtilities/include/sirf/iUtilities/DataHandle.h
+++ b/src/iUtilities/include/sirf/iUtilities/DataHandle.h
@@ -66,7 +66,7 @@ limitations under the License.
 				}\
 
 /// Typedef of vector of void pointers for a vector of handles
-typedef std::vector<const void *> DataHandleVector;
+typedef std::vector<void const *> DataHandleVector;
 
 /*!
 \ingroup C Interface to C++ Objects


### PR DESCRIPTION
`DataHandleVector` class in Python and Matlab. Can now pass though vectors of items from the wrapped languages through to the C-level (and therefore C++).