### PR TITLE
zenodo: more author metadata, and ccp-petmr community

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -9,14 +9,14 @@
   "creators": [
     {"name": "Ovtchinnikov, Evgueni"},
     {"name": "Brown, Richard", "orcid": "0000-0001-6989-9200", "affiliation": "University College London"},
-    {"name": "Thielemans, Kris", "affiliation": "UCL"},
+    {"name": "Thielemans, Kris", "orcid", "0000-0002-5514-199X", "affiliation": "University College London"},
     {"name": "Pasca, Edoardo"},
     {"name": "da Costa-Luis, Casper O.", "orcid": "0000-0002-7211-1557", "affiliation": "KCL"},
-    {"name": "Thomas, Ben", "orcid": "0000-0002-9784-1177"},
-    {"name": "Atkinson, David", "orcid": "0000-0003-1124-6666"},
+    {"name": "Thomas, Ben", "orcid": "0000-0002-9784-1177", "affiliation": "University College London"},
+    {"name": "Atkinson, David", "orcid": "0000-0003-1124-6666", "affiliation": "University College London"},
     {"name": "Mayer, Johannes", "orcid": "0000-0002-2500-445X", "affiliation": "Physikalisch-Technische Bundesanstalt (PTB)"},
     {"name": "Gillman, Ashley", "orcid": "0000-0001-9130-1092", "affiliation": "CSIRO, University of Queensland"},
     {"name": "Kolbitsch, Christoph", "orcid": "0000-0002-4355-8368", "affiliation": "Physikalisch-Technische Bundesanstalt (PTB)"},
     {"name": "Ehrhardt, Matthias J.", "affiliation": "University of Bath"},
-    {"name": "Whitehead, Alexander", "affiliation": "UCL"}]
+    {"name": "Whitehead, Alexander", "affiliation": "University College London"}]
 }}

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -8,7 +8,7 @@
   "communities": [{"identifier": "ccp-petmr"}],
   "creators": [
     {"name": "Ovtchinnikov, Evgueni"},
-    {"name": "Brown, Richard"},
+    {"name": "Brown, Richard", "orcid": "0000-0001-6989-9200", "affiliation": "University College London"},
     {"name": "Thielemans, Kris", "affiliation": "UCL"},
     {"name": "Pasca, Edoardo"},
     {"name": "da Costa-Luis, Casper O.", "orcid": "0000-0002-7211-1557", "affiliation": "KCL"},

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -2,7 +2,6 @@
   "title": "CCPPETMR SIRF",
   "keywords": [
     "image-reconstruction", "pet-mr", "medical-imaging"],
-  "license": "Apache-2.0",
   "related_identifiers": [
     {"identifier": "10.1109/NSSMIC.2017.8532815", "relation": "documents"}],
   "communities": [{"identifier": "ccp-petmr"}],
@@ -11,7 +10,7 @@
     {"name": "Brown, Richard", "orcid": "0000-0001-6989-9200", "affiliation": "University College London"},
     {"name": "Thielemans, Kris", "orcid", "0000-0002-5514-199X", "affiliation": "University College London"},
     {"name": "Pasca, Edoardo"},
-    {"name": "da Costa-Luis, Casper O.", "orcid": "0000-0002-7211-1557", "affiliation": "KCL"},
+    {"name": "da Costa-Luis, Casper O.", "orcid": "0000-0002-7211-1557", "affiliation": "King's College London"},
     {"name": "Thomas, Ben", "orcid": "0000-0002-9784-1177", "affiliation": "University College London"},
     {"name": "Atkinson, David", "orcid": "0000-0003-1124-6666", "affiliation": "University College London"},
     {"name": "Mayer, Johannes", "orcid": "0000-0002-2500-445X", "affiliation": "Physikalisch-Technische Bundesanstalt (PTB)"},

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -14,9 +14,9 @@
     {"name": "da Costa-Luis, Casper O.", "orcid": "0000-0002-7211-1557", "affiliation": "KCL"},
     {"name": "Thomas, Ben", "orcid": "0000-0002-9784-1177"},
     {"name": "Atkinson, David", "orcid": "0000-0003-1124-6666"},
-    {"name": "Mayer, Johannes", "orcid": "0000-0002-2500-445X", "affiliation": "Physikalisch-Technische Bundesanstalt"},
+    {"name": "Mayer, Johannes", "orcid": "0000-0002-2500-445X", "affiliation": "Physikalisch-Technische Bundesanstalt (PTB)"},
     {"name": "Gillman, Ashley", "orcid": "0000-0001-9130-1092", "affiliation": "CSIRO, University of Queensland"},
-    {"name": "Kolbitsch, Christoph", "orcid": "0000-0002-4355-8368"},
+    {"name": "Kolbitsch, Christoph", "orcid": "0000-0002-4355-8368", "affiliation": "Physikalisch-Technische Bundesanstalt (PTB)"},
     {"name": "Ehrhardt, Matthias J.", "affiliation": "University of Bath"},
     {"name": "Whitehead, Alexander", "affiliation": "UCL"}]
 }}

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -15,7 +15,7 @@
     {"name": "Thomas, Ben", "orcid": "0000-0002-9784-1177"},
     {"name": "Atkinson, David", "orcid": "0000-0003-1124-6666"},
     {"name": "Mayer, Johannes", "orcid": "0000-0002-2500-445X", "affiliation": "Physikalisch-Technische Bundesanstalt"},
-    {"name": "Gillman, Ashley", "affiliation": "CSIRO, University of Queensland"},
+    {"name": "Gillman, Ashley", "orcid": "0000-0001-9130-1092", "affiliation": "CSIRO, University of Queensland"},
     {"name": "Kolbitsch, Christoph", "orcid": "0000-0002-4355-8368"},
     {"name": "Ehrhardt, Matthias J.", "affiliation": "University of Bath"},
     {"name": "Whitehead, Alexander", "affiliation": "UCL"}]

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,4 +1,4 @@
-{ "metadata": {
+{
   "title": "CCPPETMR SIRF",
   "keywords": [
     "image-reconstruction", "pet-mr", "medical-imaging"],
@@ -18,4 +18,4 @@
     {"name": "Kolbitsch, Christoph", "orcid": "0000-0002-4355-8368", "affiliation": "Physikalisch-Technische Bundesanstalt (PTB)"},
     {"name": "Ehrhardt, Matthias J.", "affiliation": "University of Bath"},
     {"name": "Whitehead, Alexander", "affiliation": "University College London"}]
-}}
+}

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -2,21 +2,21 @@
   "title": "CCPPETMR SIRF",
   "keywords": [
     "image-reconstruction", "pet-mr", "medical-imaging"],
+  "license": "Apache-2.0",
+  "related_identifiers": [
+    {"identifier": "10.1109/NSSMIC.2017.8532815", "relation": "documents"}],
+  "communities": [{"identifier": "ccp-petmr"}],
   "creators": [
     {"name": "Ovtchinnikov, Evgueni"},
     {"name": "Brown, Richard"},
     {"name": "Thielemans, Kris", "affiliation": "UCL"},
     {"name": "Pasca, Edoardo"},
-    {"name": "da Costa-Luis, Casper O.",
-     "affiliation": "KCL",
-     "orcid": "0000-0002-7211-1557"},
+    {"name": "da Costa-Luis, Casper O.", "orcid": "0000-0002-7211-1557", "affiliation": "KCL"},
     {"name": "Thomas, Ben", "orcid": "0000-0002-9784-1177"},
-    {"name": "Atkinson, David"},
-    {"name": "Mayer, Johannes",
-     "affiliation": "Physikalisch-Technische Bundesanstalt"},
-    {"name": "Gillman, Ashley",
-     "affiliation": "CSIRO, University of Queensland"},
-    {"name": "Kolbitsch, Christoph"},
+    {"name": "Atkinson, David", "orcid": "0000-0003-1124-6666"},
+    {"name": "Mayer, Johannes", "orcid": "0000-0002-2500-445X", "affiliation": "Physikalisch-Technische Bundesanstalt"},
+    {"name": "Gillman, Ashley", "affiliation": "CSIRO, University of Queensland"},
+    {"name": "Kolbitsch, Christoph", "orcid": "0000-0002-4355-8368"},
     {"name": "Ehrhardt, Matthias J.", "affiliation": "University of Bath"},
     {"name": "Whitehead, Alexander", "affiliation": "UCL"}]
 }}

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -14,7 +14,7 @@
     {"name": "Thomas, Ben", "orcid": "0000-0002-9784-1177", "affiliation": "University College London"},
     {"name": "Atkinson, David", "orcid": "0000-0003-1124-6666", "affiliation": "University College London"},
     {"name": "Mayer, Johannes", "orcid": "0000-0002-2500-445X", "affiliation": "Physikalisch-Technische Bundesanstalt (PTB)"},
-    {"name": "Gillman, Ashley", "orcid": "0000-0001-9130-1092", "affiliation": "CSIRO, University of Queensland"},
+    {"name": "Gillman, Ashley", "orcid": "0000-0001-9130-1092", "affiliation": "Commonwealth Scientific and Industrial Research Organisation, and University of Queensland"},
     {"name": "Kolbitsch, Christoph", "orcid": "0000-0002-4355-8368", "affiliation": "Physikalisch-Technische Bundesanstalt (PTB)"},
     {"name": "Ehrhardt, Matthias J.", "affiliation": "University of Bath"},
     {"name": "Whitehead, Alexander", "affiliation": "University College London"}]


### PR DESCRIPTION
- add Zenodo metadata for automated release (https://doi.org/10.5281/zenodo.2707911)
  - list of authors, ORCIDs, affiliations
  - communities: [CCP-PETMR](https://zenodo.org/communities/ccp-petmr)
  - licence: ~~[Apache-2.0](https://spdx.org/licenses/Apache-2.0.html)~~ Other (for now, until GPL from FFTW is removed)
  - related DOI: [10.1109/NSSMIC.2017.8532815](https://doi.org/10.1109/NSSMIC.2017.8532815)