### PR TITLE
synergistic: include stir last

### DIFF
--- a/src/Synergistic/sirf_do_images_match.cpp
+++ b/src/Synergistic/sirf_do_images_match.cpp
@@ -28,8 +28,8 @@ limitations under the License.
 */
 
 #include "sirf/Reg/NiftiImageData3D.h"
-#include "sirf/STIR/stir_data_containers.h"
 #include "sirf/Gadgetron/gadgetron_data_containers.h"
+#include "sirf/STIR/stir_data_containers.h"
 
 
 using namespace sirf;

--- a/src/Synergistic/sirf_registration.cpp
+++ b/src/Synergistic/sirf_registration.cpp
@@ -31,8 +31,8 @@ limitations under the License.
 #include "sirf/Reg/NiftyF3dSym.h"
 #include "sirf/Reg/AffineTransformation.h"
 #include "sirf/Reg/NiftiImageData3D.h"
-#include "sirf/STIR/stir_data_containers.h"
 #include "sirf/Gadgetron/gadgetron_data_containers.h"
+#include "sirf/STIR/stir_data_containers.h"
 
 
 using namespace sirf;

--- a/src/Synergistic/sirf_resample.cpp
+++ b/src/Synergistic/sirf_resample.cpp
@@ -32,11 +32,11 @@ If multiple transformations are given, they will be applied in the order they we
 
 #include "sirf/Reg/NiftyResample.h"
 #include "sirf/Reg/NiftiImageData3D.h"
-#include "sirf/STIR/stir_data_containers.h"
 #include "sirf/Gadgetron/gadgetron_data_containers.h"
 #include "sirf/Reg/AffineTransformation.h"
 #include "sirf/Reg/NiftiImageData3DDeformation.h"
 #include "sirf/Reg/NiftiImageData3DDisplacement.h"
+#include "sirf/STIR/stir_data_containers.h"
 
 
 using namespace sirf;


### PR DESCRIPTION
Updated to boost 1.70 on OSX and error created upon building synergistic code (code that builds on STIR, Gadgetron and registration). This was solved by including STIR components last in synergistic code. 

Not sure why this was necessary, nor why it solved the problem...