### PR TITLE
bug fix: NiftiImageData::set_up_geom_info

### DIFF
--- a/src/Registration/cReg/NiftiImageData.cpp
+++ b/src/Registration/cReg/NiftiImageData.cpp
@@ -1341,7 +1341,7 @@ void NiftiImageData<dataType>::set_up_geom_info()
     VoxelisedGeometricalInfo3D::DirectionMatrix direction;
     for (unsigned i=0; i<3; ++i)
         for (unsigned j=0; j<3; ++j)
-            direction[i][j] = tm_final[i][j] / spacing[i];
+            direction[i][j] = tm_final[i][j] / spacing[j];
 
     // Initialise the geom info shared pointer
     _geom_info_sptr = std::make_shared<VoxelisedGeometricalInfo3D>(


### PR DESCRIPTION
There was a problem (detailed in #423), in which the direction matrices calculated in `NiftiImageData::set_up_geom_info` were incorrect. This is because they were sometimes divided by the wrong voxel size. This is solved by this PR