### PR TITLE
fix fork PR builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -113,8 +113,8 @@ addons:
 
 # cache C/C++/pip
 cache:
-  - ccache
-  - pip
+ - ccache
+ - pip
 
 before_install:
  # Set C and C++ compiler etc using trick from
@@ -224,6 +224,8 @@ before_install:
 
  - export PATH="$PWD:$PATH"
  - popd
+ # ensure a branch exists (for e.g. PRs)
+ - git symbolic-ref -q HEAD || git checkout -b local_$TRAVIS_COMMIT
  # Use Travis' currently checked-out SIRF commit ID to build.
  # Also no point re-downloading SIRF - just use local URL.
  # N.B.: don't put into build matrix to allow caching.


### PR DESCRIPTION
- fixes #410

Not actually sure there's a sure fire way to test that this works without merging. If it does work it's silly. If it doesn't it is still silly.

My local tests seem to work. `git checkout -qf FETCH_HEAD` means leaves no `symbolic-ref`. `checkout --branch` adds one. Similarish to https://stackoverflow.com/questions/5772192/how-can-i-reconcile-detached-head-with-master-origin. Probably something travis should fixed at their end during checkout.