### PR TITLE
osx boost thread

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,6 +69,19 @@ if (APPLE)
   endif(SHARED_LIBS_ABS_PATH)
 endif(APPLE)
 
+# If OSX, we might need to assume pthreads. For this, first try to find boost_thread.
+# If that fails, then give a bit of help.
+if (APPLE)
+  find_package(Boost COMPONENTS thread QUIET)
+  if (NOT boost_thread_FOUND)
+    set(CMAKE_THREAD_LIBS_INIT "-lpthread")
+    set(CMAKE_HAVE_THREADS_LIBRARY 1)
+    set(CMAKE_USE_WIN32_THREADS_INIT 0)
+    set(CMAKE_USE_PTHREADS_INIT 1)
+    set(THREADS_PREFER_PTHREAD_FLAG ON)
+  endif()
+endif()
+
 ####### External packages
 
 #### we need the boost library from boost.org


### PR DESCRIPTION
Sometimes OSX fails, complaining that during `find_package(BOOST)`, `Threads_FOUND` is not found. 
```
CMake Error at /Applications/CMake.app/Contents/share/cmake-3.15/Modules/FindPackageHandleStandardArgs.cmake:137 (message):
  Could NOT find Threads (missing: Threads_FOUND)
Call Stack (most recent call first):
  /Applications/CMake.app/Contents/share/cmake-3.15/Modules/FindPackageHandleStandardArgs.cmake:378 (_FPHSA_FAILURE_MESSAGE)
  /Applications/CMake.app/Contents/share/cmake-3.15/Modules/FindThreads.cmake:220 (FIND_PACKAGE_HANDLE_STANDARD_ARGS)
  /Applications/CMake.app/Contents/share/cmake-3.15/Modules/CMakeFindDependencyMacro.cmake:47 (find_package)
  /usr/local/lib/cmake/boost_thread-1.71.0/boost_thread-config.cmake:107 (find_dependency)
  /usr/local/lib/cmake/Boost-1.71.0/BoostConfig.cmake:117 (find_package)
  /usr/local/lib/cmake/Boost-1.71.0/BoostConfig.cmake:182 (boost_find_component)
  /Applications/CMake.app/Contents/share/cmake-3.15/Modules/FindBoost.cmake:443 (find_package)
  CMakeLists.txt:91 (find_package)
```

[This](https://stackoverflow.com/a/54606606) thread online solves it by assuming pthreads for OSX. So, `if(APPLE)` then `find_package(Boost COMPONENTS thread QUIET)` and `if (NOT Threads_FOUND)`, then assume pthreads and use their suggested code.