### PR TITLE
NiftiImageData: take slope and intercept into account

### DIFF
--- a/src/Registration/cReg/NiftiImageData.cpp
+++ b/src/Registration/cReg/NiftiImageData.cpp
@@ -717,11 +717,6 @@ int NiftiImageData<dataType>::get_1D_index(const int idx[7]) const
 template<class dataType>
 void NiftiImageData<dataType>::set_up_data(const int original_datatype)
 {
-	// TODO: allow slopes and intercepts != 1 and 0
-	if (std::abs( _nifti_image->scl_slope - 1.f ) > 1.e-4f ||
-		std::abs( _nifti_image->scl_inter       ) > 1.e-4f )
-		throw std::runtime_error("NiftiImageData::set_up_data: Currently only allow slope=1, intercept=0");
-
     // Save the original datatype, we'll convert it back to this just before saving
     _original_datatype = original_datatype;
 
@@ -744,7 +739,6 @@ void NiftiImageData<dataType>::set_up_data(const int original_datatype)
             _data[i] = _nifti_image->scl_slope * _data[i] + _nifti_image->scl_inter;
         _nifti_image->scl_slope = 1.f;
         _nifti_image->scl_inter = 0.f;
-
     }
 
     // Lastly, initialise the geometrical info


### PR DESCRIPTION
Turns out I'd already handled this with https://github.com/CCPPETMR/SIRF/commit/6361e82330a1158d1295f61bf03c63678709ec02 but forgot to close the issue, so I'm removing the todo guard. Fixes https://github.com/CCPPETMR/SIRF/issues/406.