### PR TITLE
tests to check for bad as_array

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -237,7 +237,7 @@ before_install:
  - cmake --version
 
 install:
- - $PY_EXE -m pip install --user --only-binary=numpy,scipy,matplotlib numpy scipy matplotlib
+ - $PY_EXE -m pip install --user --only-binary=numpy,scipy,matplotlib numpy scipy matplotlib nibabel
  - cmake $BUILD_FLAGS $EXTRA_BUILD_FLAGS .
  # Job may timeout (>50min) if no ccache, otherwise should be <1min:
  - make

--- a/src/Registration/cReg/cReg.cpp
+++ b/src/Registration/cReg/cReg.cpp
@@ -216,14 +216,14 @@ void* cReg_NiftiImageData_fill_arr(const void* ptr, size_t ptr_data)
         float *data = (float*)ptr_data;
 
         // nifti_image data are stored as u,x,y,z, whereas python and matlab need x,y,z,u
-        int nifti_idx, wrap_idx;
+        int wrap_idx;
         for (int u=0; u<dim_u; ++u) {
             for (int x=0; x<dim_x; ++x) {
                 for (int y=0; y<dim_y; ++y) {
                     for (int z=0; z<dim_z; ++z) {
+                        int nifti_idx[7] = { x,y,z,0,u,0,0 };
                         wrap_idx  = u + dim_u*(x + dim_x*(y + dim_y*(z)));
-                        nifti_idx = x + dim_x*(y + dim_y*(z + dim_z*(u)));
-                        im_data[nifti_idx] = data[wrap_idx];
+                        im(nifti_idx) = data[wrap_idx];
                     }
                 }
             }
@@ -290,14 +290,14 @@ void* cReg_NiftiImageData_as_array(const void* ptr, size_t ptr_data)
         float *data = (float*)ptr_data;
 
         // nifti_image data are stored as u,x,y,z, whereas python and matlab need x,y,z,u
-        int nifti_idx, wrap_idx;
+        int wrap_idx;
         for (int u=0; u<dim_u; ++u) {
             for (int x=0; x<dim_x; ++x) {
                 for (int y=0; y<dim_y; ++y) {
                     for (int z=0; z<dim_z; ++z) {
+                        int nifti_idx[7] = { x,y,z,0,u,0,0 };
                         wrap_idx  = u + dim_u*(x + dim_x*(y + dim_y*(z)));
-                        nifti_idx = x + dim_x*(y + dim_y*(z + dim_z*(u)));
-                        data[wrap_idx] = im_data[nifti_idx];
+                        data[wrap_idx] = im(nifti_idx);
                     }
                 }
             }

--- a/src/Registration/mReg/tests/test_mReg.m
+++ b/src/Registration/mReg/tests/test_mReg.m
@@ -198,6 +198,10 @@ if try_niftiimage
     x.fill(x_arr);
     assert(x.get_contains_nans(),'NiftiImageData::get_contains_nans() 2 failed.')
 
+    arr1 = sirf.Reg.NiftiImageData(g.ref_aladin_filename).as_array();
+    arr2 = niftiread(g.ref_aladin_filename);
+    assert(all(all(all(arr1 == arr2))), 'NiftiImageData as_array() failed.')
+
 
     disp('% ----------------------------------------------------------------------- %')
     disp('%                  Finished NiftiImageData test.')

--- a/src/Registration/pReg/tests/test_pReg.py
+++ b/src/Registration/pReg/tests/test_pReg.py
@@ -21,6 +21,7 @@ import sys
 import time
 
 import numpy as np
+import nibabel as nib
 import sirf.Reg
 from pUtilities import *
 
@@ -226,6 +227,12 @@ def try_niftiimage():
     arr_F2 = im.as_array()
     if not np.array_equal(arr_C2, arr_F2):
         raise AssertionError('NiftiImageData::fill() failed for C- or F-style numpy arrays.')
+
+    # Compare between sirf.Reg.NiftiImageData::as_array() and nibabel
+    arr1 = sirf.Reg.NiftiImageData(ref_aladin_filename).as_array()
+    arr2 = nib.load(ref_aladin_filename).get_fdata()
+    if not numpy.array_equal(arr1,arr2):
+        raise AssertionError("NiftiImageData as_array() failed.")
 
     time.sleep(0.5)
     sys.stderr.write('\n# --------------------------------------------------------------------------------- #\n')

--- a/src/Synergistic/tests/test_mSynergistic.m
+++ b/src/Synergistic/tests/test_mSynergistic.m
@@ -42,6 +42,16 @@ function try_stirtonifti(g)
     % Compare the two
     assert(image_nifti == image_nifti_from_stir, 'Conversion from STIR to Nifti failed.');
 
+    % Resample and then check that voxel values match
+    resample = sirf.Reg.NiftyResample();
+    resample.set_floating_image(image_stir);
+    resample.set_reference_image(image_nifti);
+    resample.set_interpolation_type_to_nearest_neighbour();
+    resample.process();
+
+    % as_array() of both original images should match
+    assert(all(all(all(image_nifti.as_array() == resample.get_output().as_array()))), 'as_array() of sirf.Reg.NiftiImageData and resampled sirf.STIR.ImageData are different.')
+
     disp('% ----------------------------------------------------------------------- %')
     disp('%                  Finished STIR to Nifti test.')
     disp('%------------------------------------------------------------------------ %')

--- a/src/Synergistic/tests/test_pSynergistic.py
+++ b/src/Synergistic/tests/test_pSynergistic.py
@@ -19,6 +19,7 @@
 import os
 import sys
 import time
+import numpy
 
 import sirf.STIR as pet
 import sirf.Gadgetron as mr
@@ -50,6 +51,17 @@ def try_stirtonifti():
     # Compare the two
     if image_nifti != image_nifti_from_stir:
         raise AssertionError("Conversion from STIR to Nifti failed.")
+
+    # Resample and then check that voxel values match
+    resample = reg.NiftyResample()
+    resample.set_floating_image(image_stir) 
+    resample.set_reference_image(image_nifti) 
+    resample.set_interpolation_type_to_nearest_neighbour()
+    resample.process()
+
+    # as_array() of both original images should match
+    if not numpy.array_equal(image_nifti.as_array(),resample.get_output().as_array()):
+        raise AssertionError("as_array() of sirf.Reg.NiftiImageData and resampled sirf.STIR.ImageData are different.")
 
     time.sleep(0.5)
     sys.stderr.write('\n# --------------------------------------------------------------------------------- #\n')


### PR DESCRIPTION
check that the as_array for NiftiImageData match the in-built python and matlab readers (`niftiread` in matlab and `nibabel` in python). 

Requires `pip install nibabel`