### PR TITLE
Resampler like acq model

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -199,7 +199,7 @@ before_install:
  # setuptools may be out of date on osx
  - $PY_EXE -m pip install --user -U pip setuptools wheel
  # ensure python bin dir exists (and coverage dependencies installed)
- - $PY_EXE -m pip install --user -U nose codecov coveralls requests
+ - $PY_EXE -m pip install --user -U nose codecov coveralls requests deprecation
  # for counting clones, excluding ours
  - |
     if [[ -n "$GITHUB_API_TOKEN" ]]; then

--- a/src/Registration/NiftyMoMo/BSplineTransformation.cpp
+++ b/src/Registration/NiftyMoMo/BSplineTransformation.cpp
@@ -39,7 +39,7 @@ inline void nmm_print_error(const char* message){ fprintf(stderr, "[niftyMoMo ER
 //----------------------------------------------
 BSplineTransformation::BSplineTransformation( const BSplineTransformation& transformToCopy )
 {
-#ifdef _DEBUG
+#ifndef NDEBUG
   std::cout << "Called BSplineTransformation::BSplineTransformation( const BSplineTransformation& transformToCopy )" << std::endl;
 #endif
   // Copy all parameters explicitly
@@ -91,7 +91,7 @@ BSplineTransformation::BSplineTransformation( nifti_image* referenceImageIn,
                                               linearEnergyWeight( 0.f ),
                                               lastInitialisedLevel( -1 )
 {
-#ifdef _DEBUG
+#ifndef NDEBUG
   std::cout << "Called BSplineTransformation::BSplineTransformation()" << std::endl;
 #endif
 
@@ -143,7 +143,7 @@ BSplineTransformation::BSplineTransformation( nifti_image* referenceImageIn,
 //-----------------------------------------------
 BSplineTransformation::~BSplineTransformation()
 {
-#ifdef _DEBUG
+#ifndef NDEBUG
   std::cout << "Called BSplineTransformation::~BSplineTransformation()" << std::endl;
 #endif
 
@@ -172,7 +172,7 @@ BSplineTransformation::~BSplineTransformation()
 //--------------------------------------
 BSplineTransformation::PrecisionType* BSplineTransformation::GetParameters()
 {
-#ifdef _DEBUG
+#ifndef NDEBUG
   std::cout << "Called BSplineTransformation::GetParameters()" << std::endl;
 #endif
 
@@ -187,7 +187,7 @@ BSplineTransformation::PrecisionType* BSplineTransformation::GetParameters()
 //----------------------------------------------
 unsigned int BSplineTransformation::GetNumberOfParameters()
 {
-#ifdef _DEBUG
+#ifndef NDEBUG
   std::cout << "Called BSplineTransformation::GetNumberOfParameters()" << std::endl;
 #endif
 
@@ -202,7 +202,7 @@ unsigned int BSplineTransformation::GetNumberOfParameters()
 //----------------------------------------
 void BSplineTransformation::InitialiseLevel( unsigned int levelIn )
 {
-#ifdef _DEBUG
+#ifndef NDEBUG
   std::cout << "Called BSplineTransformation::InitialiseLevel()" << std::endl;
 #endif
   
@@ -251,7 +251,7 @@ void BSplineTransformation::InitialiseLevel( unsigned int levelIn )
 //--------------------------------------------------
 nifti_image* BSplineTransformation::GetDeformationVectorField( const nifti_image * const targetImageIn )
 {
-#ifdef _DEBUG
+#ifndef NDEBUG
   std::cout << "Called BSplineTransformation::GetDeformationVectorField()" << std::endl;
 #endif
 
@@ -1281,7 +1281,7 @@ void BSplineTransformation::DVFToCPG3D( nifti_image *controlPointGridImage,
 //-------------------------------------------------------------------------
 BSplineTransformation::PrecisionType* BSplineTransformation::GetConstraintGradientWRTTransformationParameters()
 {
-#ifdef _DEBUG
+#ifndef NDEBUG
   std::cout << "Called BSplineTransformation::GetRegularisationGradientWRTTransformationParameters()" << std::endl;
 #endif
   
@@ -1314,7 +1314,7 @@ BSplineTransformation::PrecisionType* BSplineTransformation::GetConstraintGradie
 //-------------------------------------------
 double BSplineTransformation::GetConstraintValue()
 {
-#ifdef _DEBUG
+#ifndef NDEBUG
   std::cout << "Called BSplineTransformation::GetConstraintValue()" << std::endl;
 #endif
 
@@ -1339,7 +1339,7 @@ double BSplineTransformation::GetConstraintValue()
 //------------------------------------------------------------------
 BSplineTransformation::PrecisionType* BSplineTransformation::GetDVFGradientWRTTransformationParameters( nifti_image* denseDVFIn, nifti_image* sourceImage )
 {
-#ifdef _DEBUG
+#ifndef NDEBUG
   std::cout << "Called BSplineTransformation::GetDVFGradientWRTTransformationParameters()" << std::endl;
 #endif
 
@@ -1391,7 +1391,7 @@ BSplineTransformation::PrecisionType* BSplineTransformation::GetDVFGradientWRTTr
 //----------------------------------------------
 void BSplineTransformation::SetLinearEnergyWeight( double linearEnergyWeightIn )
 {
-#ifdef _DEBUG
+#ifndef NDEBUG
   std::cout << "Called BSplineTransformation::SetLinearEnergyWeight()" << std::endl;
 #endif
 
@@ -1415,7 +1415,7 @@ void BSplineTransformation::SetLinearEnergyWeight( double linearEnergyWeightIn )
 //--------------------------------------
 void BSplineTransformation::SetParameters( BSplineTransformation::PrecisionType* parametersIn, bool parametersAreDisplacements )
 {
-#ifdef _DEBUG
+#ifndef NDEBUG
   std::cout << "Called BSplineTransformation::SetParameters()" << std::endl;
 #endif
   
@@ -1441,7 +1441,7 @@ void BSplineTransformation::SetParameters( BSplineTransformation::PrecisionType*
 //-----------------------------------------------
 void BSplineTransformation::SetBendingEnergyWeight( double bendingEnergyWeightIn )
 {
-#ifdef _DEBUG
+#ifndef NDEBUG
   std::cout << "Called BSplineTransformation::SetBendingEnergyWeight()" << std::endl;
 #endif
 
@@ -1465,7 +1465,7 @@ void BSplineTransformation::SetBendingEnergyWeight( double bendingEnergyWeightIn
 //-----------------------------------------------
 BSplineTransformation::PrecisionType BSplineTransformation::GetSumOfPenaltyWeights()
 {
-#ifdef _DEBUG
+#ifndef NDEBUG
   std::cout << "Called BSplineTransformation::GetSumOfPenaltyWeights()" << std::endl;
 #endif
   
@@ -1545,7 +1545,7 @@ nifti_image * BSplineTransformation::GetTransformationAsImage()
 //---------------------------------
 std::shared_ptr<Transformation> BSplineTransformation::DeepCopy()
 {
-#ifdef _DEBUG
+#ifndef NDEBUG
   std::cout << "Called BSplineTransformation::DeepCopy()" << std::endl;
 #endif
 
@@ -1575,7 +1575,7 @@ void BSplineTransformation::DisplayTransformationParameters()
   printf( "\t* bending energy weight (at current level): %g \n", this->bendingEnergyWeight );
   printf( "\t* linear energy weight (at current level): %g \n", this->linearEnergyWeight );
 
-#ifdef _DEBUG
+#ifndef NDEBUG
   if (this->controlPointGridImage->sform_code > 0)
   {
     reg_mat44_disp( &(this->controlPointGridImage->sto_xyz), (char *)"\t* CPG sform matrix" );

--- a/src/Registration/NiftyMoMo/Transformation.cpp
+++ b/src/Registration/NiftyMoMo/Transformation.cpp
@@ -31,7 +31,7 @@ using namespace NiftyMoMo;
 //--------------------------------
 nifti_image* Transformation::TransformImage( nifti_image* sourceImgIn, nifti_image* targetImgIn )
 {
-#ifdef _DEBUG
+#ifndef NDEBUG
   std::cout << "Called Transformation::TransformImage()" << std::endl;
 #endif
   nifti_image* warpedImage;
@@ -118,7 +118,7 @@ void Transformation::TransformImageAdjoint( const nifti_image * const sourceImag
 //----------------------------------------
 void Transformation::GetImageGradientWRTDVF( nifti_image* sourceImage, nifti_image* outWarpedGradientImage )
 {
-#ifdef _DEBUG
+#ifndef NDEBUG
   std::cout << "Called Transformation::GetImageGradientWRTDVF()" << std::endl;
 #endif
 
@@ -156,7 +156,7 @@ void Transformation::setDVF( nifti_image * DVF )
 //---------------------------------------------
 bool Transformation::CheckDVFImageUpdateRequired(const nifti_image * const targetImageIn ) const
 {
-#ifdef _DEBUG
+#ifndef NDEBUG
   std::cout << "Called Transformation::CheckDVFImageUpdateRequired()" << std::endl;
 #endif
 

--- a/src/Registration/cReg/ImageWeightedMean.cpp
+++ b/src/Registration/cReg/ImageWeightedMean.cpp
@@ -70,10 +70,9 @@ void ImageWeightedMean<dataType>::process()
             resample.set_interpolation_type_to_nearest_neighbour();
             resample.set_reference_image(_input_image_sptrs[0]);
             resample.set_floating_image(_input_image_sptrs[i]);
-            resample.process();
             images_sptr.push_back(
                         std::dynamic_pointer_cast<const NiftiImageData<dataType> >(
-                            resample.get_output_sptr()));
+                            resample.forward(_input_image_sptrs[i])));
         }
     }
 

--- a/src/Registration/cReg/ImageWeightedMean.cpp
+++ b/src/Registration/cReg/ImageWeightedMean.cpp
@@ -71,7 +71,9 @@ void ImageWeightedMean<dataType>::process()
             resample.set_reference_image(_input_image_sptrs[0]);
             resample.set_floating_image(_input_image_sptrs[i]);
             resample.process();
-            images_sptr.push_back(resample.get_output_as_niftiImageData_sptr());
+            images_sptr.push_back(
+                        std::dynamic_pointer_cast<const NiftiImageData<dataType> >(
+                            resample.get_output_sptr()));
         }
     }
 

--- a/src/Registration/cReg/NiftiImageData.cpp
+++ b/src/Registration/cReg/NiftiImageData.cpp
@@ -1329,10 +1329,9 @@ bool NiftiImageData<dataType>::are_equal_to_given_accuracy(const std::shared_ptr
         resample.set_interpolation_type_to_nearest_neighbour();
         resample.set_reference_image(im1_sptr);
         resample.set_floating_image(im2_sptr);
-        resample.process();
         const std::shared_ptr<const NiftiImageData<dataType> > resampled_sptr =
                 std::dynamic_pointer_cast<const NiftiImageData<dataType> >(
-                    resample.get_output_sptr());
+                    resample.forward(im2_sptr));
         norm = resampled_sptr->get_norm(*im1_sptr);
     }
 

--- a/src/Registration/cReg/NiftiImageData.cpp
+++ b/src/Registration/cReg/NiftiImageData.cpp
@@ -1330,7 +1330,10 @@ bool NiftiImageData<dataType>::are_equal_to_given_accuracy(const std::shared_ptr
         resample.set_reference_image(im1_sptr);
         resample.set_floating_image(im2_sptr);
         resample.process();
-        norm = resample.get_output_as_niftiImageData_sptr()->get_norm(*im1_sptr);
+        const std::shared_ptr<const NiftiImageData<dataType> > resampled_sptr =
+                std::dynamic_pointer_cast<const NiftiImageData<dataType> >(
+                    resample.get_output_sptr());
+        norm = resampled_sptr->get_norm(*im1_sptr);
     }
 
     if (norm <= epsilon)

--- a/src/Registration/cReg/NiftiImageData.cpp
+++ b/src/Registration/cReg/NiftiImageData.cpp
@@ -1086,7 +1086,7 @@ void NiftiImageData<dataType>::set_voxel_spacing(const float new_spacing[3], con
     NiftiImageData<dataType> old = *this;
     nifti_image *oldImg = old.get_raw_nifti_sptr().get();
     // Create the new image
-    _nifti_image.reset(nifti_make_new_nim(newDim,_nifti_image->datatype,true));
+    _nifti_image.reset(nifti_make_new_nim(newDim,_nifti_image->datatype,true),nifti_image_free);
     nifti_image *newImg = _nifti_image.get();
 
     newImg->pixdim[1]=newImg->dx=new_spacing[0];

--- a/src/Registration/cReg/NiftyF3dSym.cpp.in
+++ b/src/Registration/cReg/NiftyF3dSym.cpp.in
@@ -96,8 +96,12 @@ void NiftyF3dSym<dataType>::process()
         this->_warped_image_nifti_sptr->get_raw_nifti_sptr()->pixdim[4] = this->_warped_image_nifti_sptr->get_raw_nifti_sptr()->dt = 0.F;
 
     // Get the CPP images
+    nifti_image * cpp_fwd_ptr = _registration_sptr->GetControlPointPositionImage();
+    nifti_image * cpp_inv_ptr = _registration_sptr->GetBackwardControlPointPositionImage();
     NiftiImageData3DTensor<dataType> cpp_forward(*_registration_sptr->GetControlPointPositionImage());
     NiftiImageData3DTensor<dataType> cpp_inverse(*_registration_sptr->GetBackwardControlPointPositionImage());
+    nifti_image_free(cpp_fwd_ptr);
+    nifti_image_free(cpp_inv_ptr);
 
     // Get deformation fields from cpp
     NiftiImageData3DDeformation<dataType> def_fwd, def_inv;

--- a/src/Registration/cReg/NiftyF3dSym.cpp.in
+++ b/src/Registration/cReg/NiftyF3dSym.cpp.in
@@ -86,9 +86,17 @@ void NiftyF3dSym<dataType>::process()
     _registration_sptr->Run();
 
     // Get the warped image
-    nifti_image *warped_im = *_registration_sptr->GetWarpedImage();
-    this->_warped_image_nifti_sptr = std::make_shared<NiftiImageData3D<dataType> >(*warped_im);
-    nifti_image_free(warped_im);
+    nifti_image **warped_im = _registration_sptr->GetWarpedImage();
+    this->_warped_image_nifti_sptr = std::make_shared<NiftiImageData3D<dataType> >(*warped_im[0]);
+    // Free the images created
+    if(warped_im[0]!=NULL)
+        nifti_image_free(warped_im[0]);
+    warped_im[0]=NULL;
+    if(warped_im[1]!=NULL)
+        nifti_image_free(warped_im[1]);
+    warped_im[1]=NULL;
+    free(warped_im);
+    warped_im=NULL;
 
     // For some reason, dt & pixdim[4] are sometimes set to 1
     if (this->_floating_image_nifti_sptr->get_raw_nifti_sptr()->dt < 1.e-7F &&
@@ -98,8 +106,8 @@ void NiftyF3dSym<dataType>::process()
     // Get the CPP images
     nifti_image * cpp_fwd_ptr = _registration_sptr->GetControlPointPositionImage();
     nifti_image * cpp_inv_ptr = _registration_sptr->GetBackwardControlPointPositionImage();
-    NiftiImageData3DTensor<dataType> cpp_forward(*_registration_sptr->GetControlPointPositionImage());
-    NiftiImageData3DTensor<dataType> cpp_inverse(*_registration_sptr->GetBackwardControlPointPositionImage());
+    NiftiImageData3DTensor<dataType> cpp_forward(*cpp_fwd_ptr);
+    NiftiImageData3DTensor<dataType> cpp_inverse(*cpp_inv_ptr);
     nifti_image_free(cpp_fwd_ptr);
     nifti_image_free(cpp_inv_ptr);
 

--- a/src/Registration/cReg/NiftyResample.cpp
+++ b/src/Registration/cReg/NiftyResample.cpp
@@ -141,7 +141,7 @@ void NiftyResample<dataType>::set_up_adjoint()
                 control_point_grid_spacing);
 
     _adjoint_transformer_sptr->set_interpolation(this->_interpolation_type);
-    _adjoint_transformer_sptr->SetParameters(static_cast<dataType*>(def_ptr->data), false);
+//    _adjoint_transformer_sptr->SetParameters(static_cast<dataType*>(def_ptr->data), false);
     _adjoint_transformer_sptr->SetPaddingValue(this->_padding_value);
     _adjoint_transformer_sptr->setDVF(def_ptr);
 

--- a/src/Registration/cReg/NiftyResample.cpp
+++ b/src/Registration/cReg/NiftyResample.cpp
@@ -115,6 +115,10 @@ void NiftyResample<dataType>::set_up_adjoint()
     // Call base level
     set_up();
 
+    // SINC currently not supported in NiftyMoMo
+    if (this->_interpolation_type == Resample<dataType>::SINC)
+        throw std::runtime_error("NiftyMoMo does not currently support SINC interpolation");
+
     // Setup output image
     set_up_output_image(_output_image_adjoint_nifti_sptr, _floating_image_nifti_sptr, _reference_image_nifti_sptr);
 
@@ -258,10 +262,6 @@ void NiftyResample<dataType>::adjoint(std::shared_ptr<ImageData> output_sptr, co
 {
     // Call the set up
     set_up_adjoint();
-
-    // SINC currently not supported in NiftyMoMo
-    if (this->_interpolation_type == Resample<dataType>::SINC)
-        throw std::runtime_error("NiftyMoMo does not currently support SINC interpolation");
 
     // Get the input image as NiftiImageData
     // Unfortunately need to clone input image, as not marked as const in NiftyReg

--- a/src/Registration/cReg/NiftyResample.cpp
+++ b/src/Registration/cReg/NiftyResample.cpp
@@ -192,6 +192,9 @@ void NiftyResample<dataType>::set_up_output_image()
 
     // Create NiftiImageData from nifti_image
     this->_output_image_nifti_sptr = std::make_shared<NiftiImageData<dataType> >(*output_ptr);
+
+    // Delete the original pointer
+    nifti_image_free(output_ptr);
 }
 
 template<class dataType>

--- a/src/Registration/cReg/Resample.cpp
+++ b/src/Registration/cReg/Resample.cpp
@@ -31,10 +31,34 @@ limitations under the License.
 
 using namespace sirf;
 
+/// Set reference image
+template<class dataType>
+void Resample<dataType>::set_reference_image(const std::shared_ptr<const ImageData> reference_image_sptr)
+{
+    _reference_image_sptr = reference_image_sptr;
+    _need_to_set_up = true;
+}
+
+/// Set floating image
+template<class dataType>
+void Resample<dataType>::set_floating_image(const std::shared_ptr<const ImageData> floating_image_sptr)
+{
+    _floating_image_sptr = floating_image_sptr;
+    _need_to_set_up = true;
+}
+
 template<class dataType>
 void Resample<dataType>::add_transformation(const std::shared_ptr<const Transformation<dataType> > transformation_sptr)
 {
     _transformations.push_back(transformation_sptr);
+    this->_need_to_set_up = true;
+}
+
+template<class dataType>
+void Resample<dataType>::set_interpolation_type(const enum InterpolationType type)
+{
+    _interpolation_type = type;
+    this->_need_to_set_up = true;
 }
 
 template<class dataType>

--- a/src/Registration/cReg/Resample.cpp
+++ b/src/Registration/cReg/Resample.cpp
@@ -81,6 +81,18 @@ void Resample<dataType>::check_parameters()
         throw std::runtime_error("Interpolation type has not been set.");
 }
 
+template<class dataType>
+std::shared_ptr<ImageData> Resample<dataType>::backward(const std::shared_ptr<const ImageData> input_sptr)
+{
+    return adjoint(input_sptr);
+}
+
+template<class dataType>
+void Resample<dataType>::backward(std::shared_ptr<ImageData> output_sptr, const std::shared_ptr<const ImageData> input_sptr)
+{
+    adjoint(output_sptr, input_sptr);
+}
+
 namespace sirf {
 template class Resample<float>;
 }

--- a/src/Registration/cReg/Resample.cpp
+++ b/src/Registration/cReg/Resample.cpp
@@ -37,6 +37,8 @@ void Resample<dataType>::set_reference_image(const std::shared_ptr<const ImageDa
 {
     _reference_image_sptr = reference_image_sptr;
     _need_to_set_up = true;
+    _need_to_set_up_forward = true;
+    _need_to_set_up_adjoint = true;
 }
 
 /// Set floating image
@@ -45,6 +47,8 @@ void Resample<dataType>::set_floating_image(const std::shared_ptr<const ImageDat
 {
     _floating_image_sptr = floating_image_sptr;
     _need_to_set_up = true;
+    _need_to_set_up_forward = true;
+    _need_to_set_up_adjoint = true;
 }
 
 template<class dataType>
@@ -52,6 +56,8 @@ void Resample<dataType>::add_transformation(const std::shared_ptr<const Transfor
 {
     _transformations.push_back(transformation_sptr);
     this->_need_to_set_up = true;
+    _need_to_set_up_forward = true;
+    _need_to_set_up_adjoint = true;
 }
 
 template<class dataType>
@@ -59,6 +65,8 @@ void Resample<dataType>::set_interpolation_type(const enum InterpolationType typ
 {
     _interpolation_type = type;
     this->_need_to_set_up = true;
+    _need_to_set_up_forward = true;
+    _need_to_set_up_adjoint = true;
 }
 
 template<class dataType>

--- a/src/Registration/cReg/cReg.cpp
+++ b/src/Registration/cReg/cReg.cpp
@@ -648,7 +648,48 @@ void* cReg_NiftyResample_process(void* ptr)
     }
     CATCH;
 }
+extern "C"
+void* cReg_NiftyResample_forward(const void* output_ptr, const void * const input_ptr, const void * resampler_ptr)
+{
+    try {
+        // Get resampler
+        std::shared_ptr<NiftyResample<float> > resampler_sptr;
+        getObjectSptrFromHandle<NiftyResample<float> >(resampler_ptr, resampler_sptr);
 
+        // Get input and output images
+        std::shared_ptr<const ImageData> input_sptr;
+        getObjectSptrFromHandle<const ImageData>(input_ptr, input_sptr);
+        std::shared_ptr<ImageData> output_sptr;
+        getObjectSptrFromHandle<ImageData>(output_ptr, output_sptr);
+
+        // Forward transformation
+        resampler_sptr->forward(output_sptr,input_sptr);
+
+        return new DataHandle;
+    }
+    CATCH;
+}
+extern "C"
+void* cReg_NiftyResample_adjoint(const void* output_ptr, const void * const input_ptr, const void * resampler_ptr)
+{
+    try {
+        // Get resampler
+        std::shared_ptr<NiftyResample<float> > resampler_sptr;
+        getObjectSptrFromHandle<NiftyResample<float> >(resampler_ptr, resampler_sptr);
+
+        // Get input and output images
+        std::shared_ptr<const ImageData> input_sptr;
+        getObjectSptrFromHandle<const ImageData>(input_ptr, input_sptr);
+        std::shared_ptr<ImageData> output_sptr;
+        getObjectSptrFromHandle<ImageData>(output_ptr, output_sptr);
+
+        // Forward transformation
+        resampler_sptr->adjoint(output_sptr,input_sptr);
+
+        return new DataHandle;
+    }
+    CATCH;
+}
 // -------------------------------------------------------------------------------- //
 //      ImageWeightedMean
 // -------------------------------------------------------------------------------- //

--- a/src/Registration/cReg/include/sirf/Reg/NiftyResample.h
+++ b/src/Registration/cReg/include/sirf/Reg/NiftyResample.h
@@ -35,6 +35,10 @@ limitations under the License.
 #include <iostream>
 #include "sirf/Reg/Resample.h"
 
+namespace NiftyMoMo {
+class BSplineTransformation;
+}
+
 namespace sirf {
 
 /*!
@@ -68,6 +72,12 @@ protected:
     /// Set up
     virtual void set_up();
 
+    /// Set up forward
+    virtual void set_up_forward();
+
+    /// Set up adjoint
+    virtual void set_up_adjoint();
+
     /// Set up the input images (convert from ImageData to NiftiImageData if necessary)
     void set_up_input_images();
 
@@ -89,5 +99,11 @@ protected:
 
     /// Deformation
     std::shared_ptr<NiftiImageData3DDeformation<dataType> > _deformation_sptr;
+    /// Needed for the adjoint transformation
+    std::shared_ptr<NiftyMoMo::BSplineTransformation> _adjoint_transformer_sptr;
+    /// Adjoint reference weights
+    std::shared_ptr<NiftiImageData<dataType> > _adjoint_input_weights_sptr;
+    /// Adjoint output weights
+    std::shared_ptr<NiftiImageData<dataType> > _adjoint_output_weights_sptr;
 };
 }

--- a/src/Registration/cReg/include/sirf/Reg/NiftyResample.h
+++ b/src/Registration/cReg/include/sirf/Reg/NiftyResample.h
@@ -65,6 +65,9 @@ public:
 
 protected:
 
+    /// Set up
+    virtual void set_up();
+
     /// Set up the input images (convert from ImageData to NiftiImageData if necessary)
     void set_up_input_images();
 
@@ -72,10 +75,10 @@ protected:
     void set_up_output_image();
 
     /// Do transformation with NiftyReg
-    void transformation_forward(NiftiImageData3DDeformation<dataType> &transformation);
+    void transformation_forward();
 
     /// Do adjoint transformation with NiftyMoMo
-    void transformation_adjoint(NiftiImageData3DDeformation<dataType> &transformation);
+    void transformation_adjoint();
 
     /// Reference image as a NiftiImageData
     std::shared_ptr<const NiftiImageData<dataType> > _reference_image_nifti_sptr;
@@ -83,5 +86,8 @@ protected:
     std::shared_ptr<const NiftiImageData<dataType> > _floating_image_nifti_sptr;
     /// Floating image as a NiftiImageData
     std::shared_ptr<NiftiImageData<dataType> >       _output_image_nifti_sptr;
+
+    /// Deformation
+    std::shared_ptr<NiftiImageData3DDeformation<dataType> > _deformation_sptr;
 };
 }

--- a/src/Registration/cReg/include/sirf/Reg/NiftyResample.h
+++ b/src/Registration/cReg/include/sirf/Reg/NiftyResample.h
@@ -68,8 +68,14 @@ public:
     /// Do the forward transformation
     virtual std::shared_ptr<ImageData> forward(const std::shared_ptr<const ImageData> input_sptr);
 
+    /// Do the forward transformation
+    virtual void forward(std::shared_ptr<ImageData> output_sptr, const std::shared_ptr<const ImageData> input_sptr);
+
     /// Do the adjoint transformation
     virtual std::shared_ptr<ImageData> adjoint(const std::shared_ptr<const ImageData> input_sptr);
+
+    /// Do the adjoint transformation
+    virtual void adjoint(std::shared_ptr<ImageData> output_sptr, const std::shared_ptr<const ImageData> input_sptr);
 
 protected:
 

--- a/src/Registration/cReg/include/sirf/Reg/NiftyResample.h
+++ b/src/Registration/cReg/include/sirf/Reg/NiftyResample.h
@@ -82,7 +82,7 @@ protected:
     void set_up_input_images();
 
     /// Set up the output image
-    void set_up_output_image();
+    void set_up_output_image(const std::shared_ptr<const NiftiImageData<dataType> > im_for_shape_sptr, const std::shared_ptr<const NiftiImageData<dataType> > im_for_metadata_sptr);
 
     /// Do transformation with NiftyReg
     void transformation_forward();

--- a/src/Registration/cReg/include/sirf/Reg/NiftyResample.h
+++ b/src/Registration/cReg/include/sirf/Reg/NiftyResample.h
@@ -34,6 +34,7 @@ limitations under the License.
 #include <vector>
 #include <iostream>
 #include "sirf/Reg/Resample.h"
+#include "sirf/iUtilities/iutilities.h"
 
 namespace NiftyMoMo {
 class BSplineTransformation;
@@ -62,7 +63,13 @@ public:
     virtual ~NiftyResample() {}
 
     /// Process
-    virtual void process();
+    DEPRECATED virtual void process();
+
+    /// Do the forward transformation
+    virtual std::shared_ptr<ImageData> forward(const std::shared_ptr<const ImageData> input_sptr);
+
+    /// Do the adjoint transformation
+    virtual std::shared_ptr<ImageData> adjoint(const std::shared_ptr<const ImageData> input_sptr);
 
 protected:
 
@@ -83,11 +90,6 @@ protected:
                              const std::shared_ptr<const NiftiImageData<dataType> > im_for_shape_sptr,
                              const std::shared_ptr<const NiftiImageData<dataType> > im_for_metadata_sptr);
 
-    /// Do transformation with NiftyReg
-    void transformation_forward();
-
-    /// Do adjoint transformation with NiftyMoMo
-    void transformation_adjoint();
 
     /// Reference image as a NiftiImageData
     std::shared_ptr<const NiftiImageData<dataType> > _reference_image_nifti_sptr;

--- a/src/Registration/cReg/include/sirf/Reg/NiftyResample.h
+++ b/src/Registration/cReg/include/sirf/Reg/NiftyResample.h
@@ -64,9 +64,6 @@ public:
     /// Process
     virtual void process();
 
-    /// Get output (as NiftiImageData)
-    const std::shared_ptr<const NiftiImageData<dataType> > get_output_as_niftiImageData_sptr() const { return _output_image_nifti_sptr; }
-
 protected:
 
     /// Set up
@@ -82,7 +79,9 @@ protected:
     void set_up_input_images();
 
     /// Set up the output image
-    void set_up_output_image(const std::shared_ptr<const NiftiImageData<dataType> > im_for_shape_sptr, const std::shared_ptr<const NiftiImageData<dataType> > im_for_metadata_sptr);
+    void set_up_output_image(std::shared_ptr<NiftiImageData<dataType> > &output_sptr,
+                             const std::shared_ptr<const NiftiImageData<dataType> > im_for_shape_sptr,
+                             const std::shared_ptr<const NiftiImageData<dataType> > im_for_metadata_sptr);
 
     /// Do transformation with NiftyReg
     void transformation_forward();
@@ -94,8 +93,10 @@ protected:
     std::shared_ptr<const NiftiImageData<dataType> > _reference_image_nifti_sptr;
     /// Floating image as a NiftiImageData
     std::shared_ptr<const NiftiImageData<dataType> > _floating_image_nifti_sptr;
-    /// Floating image as a NiftiImageData
-    std::shared_ptr<NiftiImageData<dataType> >       _output_image_nifti_sptr;
+    /// Forward resampled image as a NiftiImageData
+    std::shared_ptr<NiftiImageData<dataType> >       _output_image_forward_nifti_sptr;
+    /// Adjoint resampled image as a NiftiImageData
+    std::shared_ptr<NiftiImageData<dataType> >       _output_image_adjoint_nifti_sptr;
 
     /// Deformation
     std::shared_ptr<NiftiImageData3DDeformation<dataType> > _deformation_sptr;

--- a/src/Registration/cReg/include/sirf/Reg/Resample.h
+++ b/src/Registration/cReg/include/sirf/Reg/Resample.h
@@ -110,8 +110,14 @@ public:
     /// Do the forward transformation
     virtual std::shared_ptr<ImageData> forward(const std::shared_ptr<const ImageData> input_sptr) = 0;
 
+    /// Do the forward transformation
+    virtual void forward(std::shared_ptr<ImageData> output_sptr, const std::shared_ptr<const ImageData> input_sptr) = 0;
+
     /// Do the adjoint transformation
     virtual std::shared_ptr<ImageData> adjoint(const std::shared_ptr<const ImageData> input_sptr) = 0;
+
+    /// Do the adjoint transformation
+    virtual void adjoint(std::shared_ptr<ImageData> output_sptr, const std::shared_ptr<const ImageData> input_sptr) = 0;
 
 protected:
 

--- a/src/Registration/cReg/include/sirf/Reg/Resample.h
+++ b/src/Registration/cReg/include/sirf/Reg/Resample.h
@@ -32,6 +32,7 @@ limitations under the License.
 #include <vector>
 #include <memory>
 #include "sirf/Reg/Transformation.h"
+#include "sirf/iUtilities/iutilities.h"
 
 namespace sirf {
 
@@ -62,11 +63,6 @@ public:
         LINEAR           =  1,
         CUBICSPLINE      =  3,
         SINC             =  4
-    };
-
-    enum TransformationDirection {
-        FORWARD,
-        ADJOINT
     };
 
     /// Constructor
@@ -105,17 +101,17 @@ public:
     /// Set padding value
     void set_padding_value(const float padding_value) { _padding_value = padding_value; }
 
-    /// Set transformation direction (forward or adjoint)
-    void set_transformation_direction(const TransformationDirection transformation_direction) { _transformation_direction = transformation_direction; }
-
-    /// Get transformation direction (forward or adjoint)
-    const TransformationDirection get_transformation_direction() { return _transformation_direction; }
-
-    /// Process
-    virtual void process() = 0;
+    /// Process - will call forward
+    DEPRECATED virtual void process() = 0;
 
     /// Get output
     const std::shared_ptr<const ImageData> get_output_sptr() const { return _output_image_sptr; }
+
+    /// Do the forward transformation
+    virtual std::shared_ptr<ImageData> forward(const std::shared_ptr<const ImageData> input_sptr) = 0;
+
+    /// Do the adjoint transformation
+    virtual std::shared_ptr<ImageData> adjoint(const std::shared_ptr<const ImageData> input_sptr) = 0;
 
 protected:
 
@@ -147,10 +143,6 @@ protected:
 
     /// Padding value
     float _padding_value = 0;
-
-    /// Transformation direction
-    TransformationDirection _transformation_direction = FORWARD;
-
     bool _need_to_set_up = true;
     bool _need_to_set_up_forward = true;
     bool _need_to_set_up_adjoint = true;

--- a/src/Registration/cReg/include/sirf/Reg/Resample.h
+++ b/src/Registration/cReg/include/sirf/Reg/Resample.h
@@ -76,31 +76,28 @@ public:
     virtual ~Resample() {}
 
     /// Set reference image
-    virtual void set_reference_image(const std::shared_ptr<const ImageData> reference_image_sptr) { _reference_image_sptr = reference_image_sptr; }
+    virtual void set_reference_image(const std::shared_ptr<const ImageData> reference_image_sptr);
 
     /// Set floating image
-    virtual void set_floating_image(const std::shared_ptr<const ImageData> floating_image_sptr) { _floating_image_sptr = floating_image_sptr; }
+    virtual void set_floating_image(const std::shared_ptr<const ImageData> floating_image_sptr);
 
     /// Add transformation
     virtual void add_transformation(const std::shared_ptr<const Transformation<dataType> > transformation_sptr);
 
     /// Set interpolation type (0=nearest neighbour, 1=linear, 3=cubic, 4=sinc)
-    virtual void set_interpolation_type(const enum InterpolationType type)
-    {
-        _interpolation_type = type;
-    }
+    virtual void set_interpolation_type(const enum InterpolationType type);
 
     /// Set interpolation type to nearest neighbour
-    void set_interpolation_type_to_nearest_neighbour() { _interpolation_type = NEARESTNEIGHBOUR; }
+    void set_interpolation_type_to_nearest_neighbour() { set_interpolation_type(NEARESTNEIGHBOUR); }
 
     /// Set interpolation type to linear
-    void set_interpolation_type_to_linear() { _interpolation_type = LINEAR; }
+    void set_interpolation_type_to_linear() { set_interpolation_type(LINEAR); }
 
     /// Set interpolation type to cubic spline
-    void set_interpolation_type_to_cubic_spline() { _interpolation_type = CUBICSPLINE; }
+    void set_interpolation_type_to_cubic_spline() { set_interpolation_type(CUBICSPLINE); }
 
     /// Set interpolation type to sinc
-    void set_interpolation_type_to_sinc() { _interpolation_type = SINC; }
+    void set_interpolation_type_to_sinc() { set_interpolation_type(SINC); }
 
     /// Get interpolation type
     const InterpolationType get_interpolation_type() const { return _interpolation_type; }
@@ -121,6 +118,9 @@ public:
     const std::shared_ptr<const ImageData> get_output_sptr() const { return _output_image_sptr; }
 
 protected:
+
+    /// Set up
+    virtual void set_up() = 0;
 
     /// Check parameters
     virtual void check_parameters();
@@ -144,5 +144,9 @@ protected:
 
     /// Transformation direction
     TransformationDirection _transformation_direction = FORWARD;
+
+    bool _need_to_set_up = true;
+    bool _need_to_set_up_forward = true;
+    bool _need_to_set_up_adjoint = true;
 };
 }

--- a/src/Registration/cReg/include/sirf/Reg/Resample.h
+++ b/src/Registration/cReg/include/sirf/Reg/Resample.h
@@ -122,6 +122,12 @@ protected:
     /// Set up
     virtual void set_up() = 0;
 
+    /// Set up forward
+    virtual void set_up_forward() = 0;
+
+    /// Set up adjoint
+    virtual void set_up_adjoint() = 0;
+
     /// Check parameters
     virtual void check_parameters();
 

--- a/src/Registration/cReg/include/sirf/Reg/Resample.h
+++ b/src/Registration/cReg/include/sirf/Reg/Resample.h
@@ -119,6 +119,12 @@ public:
     /// Do the adjoint transformation
     virtual void adjoint(std::shared_ptr<ImageData> output_sptr, const std::shared_ptr<const ImageData> input_sptr) = 0;
 
+    /// Backward. Alias for Adjoint
+    virtual std::shared_ptr<ImageData> backward(const std::shared_ptr<const ImageData> input_sptr);
+
+    /// Backward. Alias for Adjoint
+    virtual void backward(std::shared_ptr<ImageData> output_sptr, const std::shared_ptr<const ImageData> input_sptr);
+
 protected:
 
     /// Set up

--- a/src/Registration/cReg/include/sirf/Reg/cReg.h
+++ b/src/Registration/cReg/include/sirf/Reg/cReg.h
@@ -87,6 +87,8 @@ extern "C" {
     // NiftyResample
     void* cReg_NiftyResample_add_transformation(void* self, const void* trans, const char* type);
     void* cReg_NiftyResample_process(void* ptr);
+    void* cReg_NiftyResample_forward(const void *output_ptr, const void * const input_ptr, const void *resampler_ptr);
+    void* cReg_NiftyResample_adjoint(const void *output_ptr, const void * const input_ptr, const void *resampler_ptr);
 
     // ImageWeightedMean
     void* cReg_ImageWeightedMean_add_image(void* ptr, const void* obj, const float weight);

--- a/src/Registration/cReg/tests/test_cReg.cpp
+++ b/src/Registration/cReg/tests/test_cReg.cpp
@@ -259,7 +259,7 @@ int main(int argc, char* argv[])
         // Do it with vectors to check
         const float *x_begin = &static_cast<const float*>(x.get_raw_nifti_sptr()->data)[0];
         const float *y_begin = &static_cast<const float*>(y.get_raw_nifti_sptr()->data)[0];
-        const float *x_end   = &static_cast<const float*>(x.get_raw_nifti_sptr()->data)[0] + x.get_num_voxels() + sizeof(float);
+        const float *x_end   = &static_cast<const float*>(x.get_raw_nifti_sptr()->data)[0] + x.get_num_voxels();
         const float inner_vec = std::inner_product(x_begin, x_end, y_begin, 0.f);
 
         if (std::abs(inner-inner_vec) > 1e-4f)

--- a/src/Registration/cReg/tests/test_cReg.cpp
+++ b/src/Registration/cReg/tests/test_cReg.cpp
@@ -879,27 +879,21 @@ int main(int argc, char* argv[])
         int max_idx[7] = {y_dims[1]-3,y_dims[2]-1,y_dims[3]-5-1,-1,-1,-1};
         y->crop(min_idx,max_idx);
 
+        NiftyResample<float> nr;
+        nr.set_reference_image(x);
+        nr.set_floating_image(y);
+        nr.set_interpolation_type(Resample<float>::LINEAR);
+        nr.add_transformation(T);
+
         // Do the forward
-        std::cout << "Testing adjoint resample...\n";
-        // NiftyReg and NiftyMoMo forward resamples
-        NiftyResample<float> nr_forward;
-        nr_forward.set_reference_image(x);
-        nr_forward.set_floating_image(y);
-        nr_forward.set_interpolation_type(Resample<float>::LINEAR);
-        nr_forward.add_transformation(T);
         const std::shared_ptr<const NiftiImageData<float> > Ty =
                 std::dynamic_pointer_cast<const NiftiImageData<float> >(
-                    nr_forward.forward(y));
+                    nr.forward(y));
 
         // Do the adjoint
-        NiftyResample<float> nr_adjoint;
-        nr_adjoint.set_reference_image(x);
-        nr_adjoint.set_floating_image(y);
-        nr_adjoint.set_interpolation_type(nr_forward.get_interpolation_type());
-        nr_adjoint.add_transformation(T);
         const std::shared_ptr<const NiftiImageData<float> > Tsx =
                 std::dynamic_pointer_cast<const NiftiImageData<float> >(
-                    nr_adjoint.adjoint(x));
+                    nr.adjoint(x));
 
         // Check the adjoint is truly the adjoint with: |<x, Ty> - <y, Tsx>| / 0.5*(|<x, Ty>|+|<y, Tsx>|) < epsilon
         float inner_x_Ty  = x->get_inner_product(*Ty);

--- a/src/Registration/cReg/tests/test_cReg.cpp
+++ b/src/Registration/cReg/tests/test_cReg.cpp
@@ -840,6 +840,19 @@ int main(int argc, char* argv[])
         nr3.process();
         nr3.get_output_sptr()->write(nonrigid_resample_def);
 
+        // Check that the following give the same result
+        //      out = resample.forward(in)
+        //      resample.forward(out, in)
+        const std::shared_ptr<const NiftiImageData<float> > out1_sptr =
+                std::dynamic_pointer_cast<const NiftiImageData<float> >(
+                    nr3.forward(flo_aladin));
+
+        const std::shared_ptr<NiftiImageData<float> > out2_sptr = ref_aladin->clone();
+        nr3.forward(out2_sptr, flo_aladin);
+
+        if (*out1_sptr != *out2_sptr)
+            throw std::runtime_error("out = NiftyResample::forward(in) and NiftyResample::forward(out, in) do not give same result.");
+
         // TODO this doesn't work. For some reason (even with NiftyReg directly), resampling with the TM from the registration
         // doesn't give the same result as the output from the registration itself (even with same interpolations). Even though
         // ref and flo images are positive, the output of the registration can be negative. This implies that linear interpolation
@@ -904,6 +917,19 @@ int main(int argc, char* argv[])
         std::cout << "|<x, Ty> - <y, Tsx>| / 0.5*(|<x, Ty>|+|<y, Tsx>|) = " << adjoint_test << "\n";
         if (adjoint_test > 1e-4F)
             throw std::runtime_error("NiftyResample::adjoint() failed");
+
+        // Check that the following give the same result
+        //      out = resample.adjoint(in)
+        //      resample.adjoint(out, in)
+        const std::shared_ptr<const NiftiImageData<float> > out1_sptr =
+                std::dynamic_pointer_cast<const NiftiImageData<float> >(
+                    nr.adjoint(x));
+
+        const std::shared_ptr<NiftiImageData<float> > out2_sptr = y->clone();
+        nr.backward(out2_sptr, x);
+
+        if (*out1_sptr != *out2_sptr)
+            throw std::runtime_error("out = NiftyResample::adjoint(in) and NiftyResample::adjoint(out, in) do not give same result.");
 
         std::cout << "// ----------------------------------------------------------------------- //\n";
         std::cout << "//                  Finished NiftyMoMo test.\n";

--- a/src/Registration/cReg/tests/test_cReg.cpp
+++ b/src/Registration/cReg/tests/test_cReg.cpp
@@ -881,7 +881,7 @@ int main(int argc, char* argv[])
                 std::make_shared<AffineTransformation<float> >(*
                 NA.get_transformation_matrix_forward_sptr());
         const std::shared_ptr<NiftiImageData<float> > y  =
-                std::make_shared<NiftiImageData3D<float> >(flo_f3d_filename);
+                std::make_shared<NiftiImageData3D<float> >(flo_aladin_filename);
 
         // Add in a magnification to make things interesting
         (*T)[0][0] = 1.5f;

--- a/src/Registration/cReg/tests/test_cReg.cpp
+++ b/src/Registration/cReg/tests/test_cReg.cpp
@@ -894,8 +894,8 @@ int main(int argc, char* argv[])
 
         // Do the adjoint
         NiftyResample<float> nr_adjoint;
-        nr_adjoint.set_reference_image(y);
-        nr_adjoint.set_floating_image(x);
+        nr_adjoint.set_reference_image(x);
+        nr_adjoint.set_floating_image(y);
         nr_adjoint.set_interpolation_type(nr_forward.get_interpolation_type());
         nr_adjoint.set_transformation_direction(Resample<float>::ADJOINT);
         nr_adjoint.add_transformation(T);

--- a/src/Registration/cReg/tests/test_cReg.cpp
+++ b/src/Registration/cReg/tests/test_cReg.cpp
@@ -885,24 +885,20 @@ int main(int argc, char* argv[])
         nr_forward.set_reference_image(x);
         nr_forward.set_floating_image(y);
         nr_forward.set_interpolation_type(Resample<float>::LINEAR);
-        nr_forward.set_transformation_direction(Resample<float>::FORWARD);
         nr_forward.add_transformation(T);
-        nr_forward.process();
         const std::shared_ptr<const NiftiImageData<float> > Ty =
                 std::dynamic_pointer_cast<const NiftiImageData<float> >(
-                    nr_forward.get_output_sptr());
+                    nr_forward.forward(y));
 
         // Do the adjoint
         NiftyResample<float> nr_adjoint;
         nr_adjoint.set_reference_image(x);
         nr_adjoint.set_floating_image(y);
         nr_adjoint.set_interpolation_type(nr_forward.get_interpolation_type());
-        nr_adjoint.set_transformation_direction(Resample<float>::ADJOINT);
         nr_adjoint.add_transformation(T);
-        nr_adjoint.process();
         const std::shared_ptr<const NiftiImageData<float> > Tsx =
                 std::dynamic_pointer_cast<const NiftiImageData<float> >(
-                    nr_adjoint.get_output_sptr());
+                    nr_adjoint.adjoint(x));
 
         // Check the adjoint is truly the adjoint with: |<x, Ty> - <y, Tsx>| / 0.5*(|<x, Ty>|+|<y, Tsx>|) < epsilon
         float inner_x_Ty  = x->get_inner_product(*Ty);

--- a/src/Registration/cReg/tests/test_cReg.cpp
+++ b/src/Registration/cReg/tests/test_cReg.cpp
@@ -862,12 +862,13 @@ int main(int argc, char* argv[])
         //      |<x, Ty> - <y, Tsx>| / 0.5*(|<x, Ty>|+|<y, Tsx>|) < epsilon
         // for all images x and y, where T is the transform and Ts is the adjoint.
 
-        const std::shared_ptr<const NiftiImageData<float> > x = ref_aladin;
+        const std::shared_ptr<const NiftiImageData<float> > x =
+                std::make_shared<const NiftiImageData<float> >(ref_aladin_filename);
         const std::shared_ptr<AffineTransformation<float> > T =
                 std::make_shared<AffineTransformation<float> >(*
                 NA.get_transformation_matrix_forward_sptr());
         const std::shared_ptr<NiftiImageData<float> > y  =
-                std::make_shared<NiftiImageData3D<float> >(*flo_aladin);
+                std::make_shared<NiftiImageData3D<float> >(flo_f3d_filename);
 
         // Add in a magnification to make things interesting
         (*T)[0][0] = 1.5f;

--- a/src/Registration/mReg/+sirf/+Reg/NiftyResample.m
+++ b/src/Registration/mReg/+sirf/+Reg/NiftyResample.m
@@ -22,6 +22,7 @@ classdef NiftyResample < handle
         name
         handle_
         reference_image
+        floating_image
     end
     methods(Static)
         function name = class_name()
@@ -49,6 +50,7 @@ classdef NiftyResample < handle
         function set_floating_image(self, floating_image)
             %Set floating image.
             assert(isa(floating_image, 'sirf.SIRF.ImageData'), 'NiftyResample::set_floating_image expects sirf.SIRF.ImageData')
+            self.floating_image = floating_image;
             sirf.Reg.setParameter(self.handle_, self.name, 'floating_image', floating_image, 'h')
         end
         function add_transformation(self, src)
@@ -100,6 +102,66 @@ classdef NiftyResample < handle
             sirf.Utilities.delete(output.handle_)
             output.handle_ = calllib('mreg', 'mParameter', self.handle_, self.name, 'output');
             sirf.Utilities.check_status([self.name ':get_output'], output.handle_)
+        end
+        function output_im = forward(self, im1, im2)
+            %Forward transformation.
+            %Usage:
+            %   output = forward(input), OR
+            %   forward(output,input)
+            narginchk(2,3)
+
+            % If usage was 'output = forward(input)'
+            if nargin == 2
+                output_im = self.reference_image.deep_copy();
+                input_im = im1;
+            % If usage was 'forward(output, input)'
+            else
+                assert(nargout == 0, 'NiftyResample::forward too many output arguments')
+                output_im = im1;
+                input_im = im2;
+            end
+            % Check image validity
+            assert(isa(output_im, 'sirf.SIRF.ImageData'), 'NiftyResample::forward expects sirf.SIRF.ImageData')
+            assert(isa(input_im,  'sirf.SIRF.ImageData'), 'NiftyResample::forward expects sirf.SIRF.ImageData')
+            % Forward
+            h = calllib('mreg', 'mReg_NiftyResample_forward', output_im.handle_, input_im.handle_, self.handle_);
+            sirf.Utilities.check_status([self.name ':forward'], h);
+            sirf.Utilities.delete(h)
+        end
+        function output_im = adjoint(self, im1, im2)
+            %Adjoint transformation.
+            %Usage:
+            %   output = adjoint(input), OR
+            %   adjoint(output,input)
+            narginchk(2,3)
+
+            % If usage was 'output = adjoint(input)'
+            if nargin == 2
+                output_im = self.floating_image.deep_copy();
+                input_im = im1;
+            % If usage was 'adjoint(output, input)'
+            else
+                assert(nargout == 0, 'NiftyResample::adjoint too many output arguments')
+                output_im = im1;
+                input_im = im2;
+            end
+            % Check image validity
+            assert(isa(output_im, 'sirf.SIRF.ImageData'), 'NiftyResample::forward expects sirf.SIRF.ImageData')
+            assert(isa(input_im,  'sirf.SIRF.ImageData'), 'NiftyResample::forward expects sirf.SIRF.ImageData')
+            % Adjoint
+            h = calllib('mreg', 'mReg_NiftyResample_adjoint', output_im.handle_, input_im.handle_, self.handle_);
+            sirf.Utilities.check_status([self.name ':adjoint'], h);
+            sirf.Utilities.delete(h)
+        end
+        function output_im = backward(self, im1, im2)
+            % Alias for adjoint.
+            narginchk(2,3)
+            if nargin == 2
+                output_im = self.adjoint(im1);
+            else %nargin == 3
+                assert(nargout == 0, 'NiftyResample::backward too many output arguments')
+                self.adjoint(im1,im2);
+            end
         end
     end
 end

--- a/src/Registration/mReg/mreg.c
+++ b/src/Registration/mReg/mreg.c
@@ -147,6 +147,12 @@ EXPORTED_FUNCTION     void* mReg_NiftyResample_add_transformation(void* self, co
 EXPORTED_FUNCTION     void* mReg_NiftyResample_process(void* ptr) {
 	return cReg_NiftyResample_process(ptr);
 }
+EXPORTED_FUNCTION     void* mReg_NiftyResample_forward(const void *output_ptr, const void * const input_ptr, const void *resampler_ptr) {
+	return cReg_NiftyResample_forward(output_ptr, input_ptr, resampler_ptr);
+}
+EXPORTED_FUNCTION     void* mReg_NiftyResample_adjoint(const void *output_ptr, const void * const input_ptr, const void *resampler_ptr) {
+	return cReg_NiftyResample_adjoint(output_ptr, input_ptr, resampler_ptr);
+}
 EXPORTED_FUNCTION     void* mReg_ImageWeightedMean_add_image(void* ptr, const void* obj, const float weight) {
 	return cReg_ImageWeightedMean_add_image(ptr, obj, weight);
 }

--- a/src/Registration/mReg/mreg.h
+++ b/src/Registration/mReg/mreg.h
@@ -72,6 +72,8 @@ EXPORTED_FUNCTION     void* mReg_Registration_print_all_wrapped_methods(const ch
 EXPORTED_FUNCTION     void* mReg_NiftyAladin_get_TM(const void* ptr, const char* dir);
 EXPORTED_FUNCTION     void* mReg_NiftyResample_add_transformation(void* self, const void* trans, const char* type);
 EXPORTED_FUNCTION     void* mReg_NiftyResample_process(void* ptr);
+EXPORTED_FUNCTION     void* mReg_NiftyResample_forward(const void *output_ptr, const void * const input_ptr, const void *resampler_ptr);
+EXPORTED_FUNCTION     void* mReg_NiftyResample_adjoint(const void *output_ptr, const void * const input_ptr, const void *resampler_ptr);
 EXPORTED_FUNCTION     void* mReg_ImageWeightedMean_add_image(void* ptr, const void* obj, const float weight);
 EXPORTED_FUNCTION     void* mReg_ImageWeightedMean_add_image_filename(void* ptr, const char* filename, const float weight);
 EXPORTED_FUNCTION     void* mReg_ImageWeightedMean_process(void* ptr);

--- a/src/Registration/mReg/tests/test_mReg.m
+++ b/src/Registration/mReg/tests/test_mReg.m
@@ -58,6 +58,7 @@ g.f3d_disp_inverse                           = fullfile(output_prefix, 'matlab_f
 g.rigid_resample                             = fullfile(output_prefix, 'matlab_rigid_resample.nii');
 g.nonrigid_resample_disp                     = fullfile(output_prefix, 'matlab_nonrigid_resample_disp.nii');
 g.nonrigid_resample_def                      = fullfile(output_prefix, 'matlab_nonrigid_resample_def.nii');
+g.niftymomo_resample_adj                     = fullfile(output_prefix, 'matlab_niftymomo_resample_adj.nii');
 g.output_weighted_mean                       = fullfile(output_prefix, 'matlab_weighted_mean.nii');
 g.output_weighted_mean_def                   = fullfile(output_prefix, 'matlab_weighted_mean_def.nii');
 g.output_float                               = fullfile(output_prefix, 'matlab_reg_aladin_float.nii');
@@ -77,6 +78,7 @@ try_niftyaladin = true;
 try_niftyf3d = true;
 try_transformations = true;
 try_resample = true;
+try_niftymomo = true;
 try_weighted_mean = true;
 try_affinetransformation = true;
 try_quaternion = true;
@@ -535,6 +537,8 @@ if try_niftyaladin
     na.set_parameter('SetInterpolationToCubic');
     na.set_parameter('SetLevelsToPerform', '1');
     na.set_parameter('SetMaxIterations', '5');
+    na.set_parameter('SetPerformRigid', '1');
+    na.set_parameter('SetPerformAffine', '0');
     na.set_reference_mask(ref_mask);
     na.set_floating_mask(flo_mask);
     na.process();
@@ -691,6 +695,14 @@ if try_resample
     nr3.process()
     nr3.get_output().write(g.nonrigid_resample_def)
 
+    % Check that the following give the same result
+    %       out = resample.forward(in)
+    %       resample.forward(out, in)
+    out1 = nr3.forward(g.flo_aladin);
+    out2 = g.ref_aladin.deep_copy();
+    nr3.forward(out2, g.flo_aladin);
+    assert(out1 == out2, 'out = NiftyResample::forward(in) and NiftyResample::forward(out, in) do not give same result.')
+
     % TODO this doesn't work. For some reason (even with NiftyReg directly), resampling with the TM from the registration
     % doesn't give the same result as the output from the registration itself (even with same interpolations). Even though 
     % ref and flo images are positive, the output of the registration can be negative. This implies that linear interpolation 
@@ -699,6 +711,65 @@ if try_resample
 
     disp('% ----------------------------------------------------------------------- %')
     disp('%                  Finished Nifty resample test.')
+    disp('%------------------------------------------------------------------------ %')
+end
+
+if try_niftymomo
+    disp('% ----------------------------------------------------------------------- %')
+    disp('%                  Starting NiftyMomMo test...')
+    disp('%------------------------------------------------------------------------ %')
+
+    % The forward and the adjoint should meet the following criterion:
+    % | < x, Ty > - < y, Tsx > | / 0.5 * (| < x, Ty > | + | < y, Tsx > |) < epsilon
+    % for all images x and y, where T is the transform and Ts is the adjoint.
+
+    x = g.ref_aladin;
+    T = na.get_transformation_matrix_forward();
+    y = g.flo_aladin;
+
+    % Add in a magnification to make things interesting
+    t = T.as_array();
+    t(1,1) = 1.5;
+    T = sirf.Reg.AffineTransformation(t);
+
+    % make it slightly unsquare to spice things up
+    min_idx = [1,2,3];
+    y_dims = y.get_dimensions();
+    max_idx = [y_dims(2) - 3, y_dims(3) - 1, y_dims(4) - 5];
+    y.crop(min_idx, max_idx);
+
+    disp('Testing adjoint resample..')
+    nr = sirf.Reg.NiftyResample();
+    nr.set_reference_image(x);
+    nr.set_floating_image(y);
+    nr.set_interpolation_type_to_linear();
+    nr.add_transformation(T);
+
+    % Do the forward
+    Ty = nr.forward(y);
+
+    % Do the adjoint
+    Tsx = nr.adjoint(x);
+
+    % Check the adjoint is truly the adjoint with: |<x, Ty> - <y, Tsx>| / 0.5*(|<x, Ty>|+|<y, Tsx>|) < epsilon
+    inner_x_Ty = x.get_inner_product(Ty);
+    inner_y_Tsx = y.get_inner_product(Tsx);
+    adjoint_test = abs(inner_x_Ty - inner_y_Tsx) / (0.5 * (abs(inner_x_Ty) + abs(inner_y_Tsx)));
+    disp(['<x, Ty>  = ' num2str(inner_x_Ty)])
+    disp(['<y, Tsx> = ' num2str(inner_y_Tsx)])
+    disp(['|<x, Ty> - <y, Tsx>| / 0.5*(|<x, Ty>|+|<y, Tsx>|) = ' num2str(adjoint_test)])
+    assert(adjoint_test < 1e-4, 'NiftyResample::adjoint() failed')
+
+    % Check that the following give the same result
+    %       out = resample.adjoint(in)
+    %       resample.adjoint(out, in)
+    out1 = nr.adjoint(x);
+    out2 = y.deep_copy();
+    nr.backward(out2, x);
+    assert(out1 == out2, 'out = NiftyResample::adjoint(in) and NiftyResample::adjoint(out, in) do not give same result.')
+
+    disp('% ----------------------------------------------------------------------- %')
+    disp('%                  Finished NiftyMomMo test.')
     disp('%------------------------------------------------------------------------ %')
 end
 

--- a/src/iUtilities/include/sirf/iUtilities/iutilities.h
+++ b/src/iUtilities/include/sirf/iUtilities/iutilities.h
@@ -20,6 +20,16 @@ limitations under the License.
 #ifndef INTERFACE_UTILITIES
 #define INTERFACE_UTILITIES
 
+// Deprecation function. With C++14, could use [[deprecated("some message")]]
+#if defined(__GNUC__) || defined(__clang__)
+#define DEPRECATED __attribute__((deprecated))
+#elif defined(_MSC_VER)
+#define DEPRECATED __declspec(deprecated)
+#else
+#pragma message("WARNING: You need to implement DEPRECATED for this compiler")
+#define DEPRECATED
+#endif
+
 #ifndef IUTILITIES_FOR_MATLAB
 extern "C" {
 #endif


### PR DESCRIPTION
add `forward` and `adjoint`/`backward` transformations to the resampler so that it mirrors functionality in `AcquisitionModel`.