### PR TITLE
applied quick fix to enable using both old and new Gadgetron

### DIFF
--- a/src/xGadgetron/cGadgetron/include/sirf/Gadgetron/gadgetron_x.h
+++ b/src/xGadgetron/cGadgetron/include/sirf/Gadgetron/gadgetron_x.h
@@ -207,9 +207,6 @@ namespace sirf {
 			sptr_acqs_.reset();
 			add_reader("reader", reader_);
 			add_writer("writer", writer_);
-			gadgetron::shared_ptr<AcquisitionFinishGadget>
-				endgadget(new AcquisitionFinishGadget);
-			set_endgadget(endgadget);
 		}
 		// apparently caused crash in linux
 		//virtual ~AcquisitionsProcessor() {}


### PR DESCRIPTION
Old Gadgetron required `AcquisitionFinishGadget` at the end of acquisition processing chains.

The latest one does not need this gadget any more, and so no longer has dll for it in the library.

So, we need to find out which Gadgetron is running on the server.

Quick solution: send  just one acquisition to the chain without `AcquisitionFinishGadget`, and if there is no output append this gadget to the chain. Then send the whole acquisition data. 

No changes needed in any of our scripts.