### PR TITLE
Exposing AcquisitionData functionality to Python

### DIFF
--- a/src/xGadgetron/cGadgetron/cgadgetron.cpp
+++ b/src/xGadgetron/cGadgetron/cgadgetron.cpp
@@ -484,12 +484,32 @@ cGT_sortAcquisitions(void* ptr_acqs)
 	CATCH;
 }
 
+extern "C"
+void*
+cGT_sortAcquisitionsByTime(void* ptr_acqs)
+{
+	try {
+		CAST_PTR(DataHandle, h_acqs, ptr_acqs);
+		MRAcquisitionData& acqs =
+			objectFromHandle<MRAcquisitionData>(h_acqs);
+		acqs.sort_by_time();
+
+		return (void*)new DataHandle;
+	}
+	CATCH;
+}
 
 
 extern "C"
 void*
 cGT_ISMRMRDAcquisitionsFromFile(const char* file)
 {
+	if(strlen(file)<1)
+	{
+		shared_ptr<MRAcquisitionData> 
+			acquisitions(new AcquisitionsFile(AcquisitionsInfo()));
+		return newObjectHandle<MRAcquisitionData>(acquisitions);
+	}
 	if (!file_exists(file))
 		return fileNotFound(file, __FILE__, __LINE__);
 	try {
@@ -556,6 +576,22 @@ cGT_acquisitionFromContainer(void* ptr_acqs, unsigned int acq_num)
 			sptr_acq(new ISMRMRD::Acquisition);
 		acqs.get_acquisition(acq_num, *sptr_acq);
 		return newObjectHandle<ISMRMRD::Acquisition>(sptr_acq);
+	}
+	CATCH;
+}
+
+extern "C"
+void*
+cGT_appendAcquisition(void* ptr_acqs, void* ptr_acq)
+{
+	try {
+		CAST_PTR(DataHandle, h_acqs, ptr_acqs);
+		MRAcquisitionData& acqs =
+			objectFromHandle<MRAcquisitionData>(h_acqs);
+		ISMRMRD::Acquisition& acq = 
+			objectFromHandle<ISMRMRD::Acquisition>(ptr_acq);
+		acqs.append_acquisition(acq);
+		return new DataHandle;
 	}
 	CATCH;
 }
@@ -720,6 +756,21 @@ cGT_acquisitionsParameter(void* ptr_acqs, const char* name)
 		return parameterNotFound(name, __FILE__, __LINE__);
 	}
 	CATCH;
+}
+
+extern "C"
+void*
+cGT_setAcquisitionsInfo(void* ptr_acqs, const char* info)
+{
+	try {
+		CAST_PTR(DataHandle, h_acqs, ptr_acqs);
+		MRAcquisitionData& acqs =
+			objectFromHandle<MRAcquisitionData>(h_acqs);
+		acqs.set_acquisitions_info(info);
+		return new DataHandle;
+	}
+	CATCH;
+
 }
 
 extern "C"

--- a/src/xGadgetron/cGadgetron/cgadgetron.cpp
+++ b/src/xGadgetron/cGadgetron/cgadgetron.cpp
@@ -134,7 +134,6 @@ void* cGT_newObject(const char* name)
 		NEW_GADGET(GenericReconCartesianReferencePrepGadget);
 		NEW_GADGET(GenericReconCartesianGrappaGadget);
 		NEW_GADGET(SimpleReconGadget);
-        NEW_GADGET(GenericReconCartesianFFTGadget);
 		NEW_GADGET(GenericReconFieldOfViewAdjustmentGadget);
 		NEW_GADGET(GenericReconImageArrayScalingGadget);
 		NEW_GADGET(FatWaterGadget);
@@ -485,6 +484,8 @@ cGT_sortAcquisitions(void* ptr_acqs)
 	CATCH;
 }
 
+
+
 extern "C"
 void*
 cGT_ISMRMRDAcquisitionsFromFile(const char* file)
@@ -629,6 +630,9 @@ cGT_writeAcquisitions(void* ptr_acqs, const char* filename)
 	CATCH;
 }
 
+
+
+
 extern "C"
 void*
 cGT_acquisitionParameter(void* ptr_acq, const char* name)
@@ -711,6 +715,8 @@ cGT_acquisitionsParameter(void* ptr_acqs, const char* name)
 			return dataHandle((int)acqs.undersampled());
 		if (boost::iequals(name, "sorted"))
 			return dataHandle((int)acqs.sorted());
+		if (boost::iequals(name, "info"))
+			return charDataHandleFromCharData(acqs.acquisitions_info().c_str());
 		return parameterNotFound(name, __FILE__, __LINE__);
 	}
 	CATCH;
@@ -858,19 +864,17 @@ cGT_writeImages(void* ptr_imgs, const char* filename, const char* ext)
 	try {
 		CAST_PTR(DataHandle, h_imgs, ptr_imgs);
 		GadgetronImageData& imgs = objectFromHandle<GadgetronImageData>(h_imgs);
-        // If .h5
-		if (strcmp(ext, "h5") == 0) {
+		if (strcmp(ext, "dcm")) {
 			std::string fullname(filename);
 			fullname += ".";
 			fullname += ext;
 			imgs.write(fullname);
 		}
-        // Else if dicom
-		else if (strcmp(ext, "dcm") == 0) {
-            imgs.write(filename,"",true);
+		else {
+//			std::cout << "in cGT_writeImages\n";
+			ImagesProcessor ip(true, filename);
+			ip.process(imgs);
 		}
-        else
-            throw std::runtime_error("cGT_writeImages: Unknown extension");
 	}
 	CATCH;
 

--- a/src/xGadgetron/cGadgetron/include/sirf/Gadgetron/cgadgetron.h
+++ b/src/xGadgetron/cGadgetron/include/sirf/Gadgetron/cgadgetron.h
@@ -71,8 +71,11 @@ extern "C" {
 	void* cGT_ISMRMRDAcquisitionsFile(const char* file);
 	void* cGT_processAcquisitions(void* ptr_proc, void* ptr_input);
 	void* cGT_acquisitionFromContainer(void* ptr_acqs, unsigned int acq_num);
+	void* cGT_appendAcquisition(void* ptr_acqs, void* ptr_acq);
 	void* cGT_cloneAcquisitions(void* ptr_input);
 	void* cGT_sortAcquisitions(void* ptr_acqs);
+	void* cGT_sortAcquisitionsByTime(void* ptr_acqs);
+	void* cGT_setAcquisitionsInfo(void* ptr_acqs, const char* info);
 	void* cGT_getAcquisitionDataDimensions(void* ptr_acqs, PTR_INT ptr_dim);
 	void* cGT_writeAcquisitions(void* ptr_acqs, const char* filename);
 	void* cGT_fillAcquisitionData(void* ptr_acqs, PTR_FLOAT ptr_z, int all);

--- a/src/xGadgetron/pGadgetron/Gadgetron.py
+++ b/src/xGadgetron/pGadgetron/Gadgetron.py
@@ -806,6 +806,9 @@ class AcquisitionData(DataContainer):
     def is_undersampled(self):
         assert self.handle is not None
         return parms.int_par(self.handle, 'acquisitions', 'undersampled')
+    def get_header(self):
+        assert self.handle is not None
+        return params.char_par(self.handle, 'acquisitions', 'info')
     def process(self, list):
         '''
         Returns processed self with an acquisition processor specified by

--- a/src/xGadgetron/pGadgetron/Gadgetron.py
+++ b/src/xGadgetron/pGadgetron/Gadgetron.py
@@ -756,6 +756,7 @@ class AcquisitionData(DataContainer):
         if file is not None:
             self.handle = pygadgetron.cGT_ISMRMRDAcquisitionsFromFile(file)
             check_status(self.handle)
+
     def __del__(self):
         if self.handle is not None:
             pyiutil.deleteDataHandle(self.handle)
@@ -799,6 +800,13 @@ class AcquisitionData(DataContainer):
         assert self.handle is not None
         try_calling(pygadgetron.cGT_sortAcquisitions(self.handle))
         self.sorted = True
+    def sort_by_time(self):
+        '''
+        Sorts acquisitions with respect to:
+            - acquisition_time_stamp
+        '''
+        assert self.handle is not None
+        try_calling(pygadgetron.cGT_sortAcquisitionsByTime(self.handle))
     def is_sorted(self):
         assert self.handle is not None
         return parms.int_par(self.handle, 'acquisitions', 'sorted')
@@ -806,9 +814,13 @@ class AcquisitionData(DataContainer):
     def is_undersampled(self):
         assert self.handle is not None
         return parms.int_par(self.handle, 'acquisitions', 'undersampled')
+    def set_header(self, header):
+        assert self.handle is not None
+        try_calling(pygadgetron.cGT_setAcquisitionsInfo(self.handle, header))
+
     def get_header(self):
         assert self.handle is not None
-        return params.char_par(self.handle, 'acquisitions', 'info')
+        return parms.char_par(self.handle, 'acquisitions', 'info')
     def process(self, list):
         '''
         Returns processed self with an acquisition processor specified by
@@ -829,6 +841,13 @@ class AcquisitionData(DataContainer):
         acq = Acquisition()
         acq.handle = pygadgetron.cGT_acquisitionFromContainer(self.handle, num)
         return acq
+    def append_acquisition(self, acq):
+        '''
+        Appends acquistion to AcquisitionData.
+        '''
+        assert self.handle is not None
+        try_calling( pygadgetron.cGT_appendAcquisition(self.handle, acq.handle))
+
     def dimensions(self, select = 'image'):
         '''
         Returns acquisitions dimensions as a tuple (na, nc, ns), where na is
@@ -981,6 +1000,10 @@ class AcquisitionData(DataContainer):
             tmp = value * numpy.ones(out.as_array().shape)
             out.fill(tmp)
         return out
+    
+    def write(self, filename):
+        assert self.handle is not None
+        try_calling(pygadgetron.cGT_writeAcquisitions(self.handle, filename))
 
 DataContainer.register(AcquisitionData)
 


### PR DESCRIPTION
Multiple functions to handle AcquisitionData from Python are included.
Namely 
- `set_header( ismrmrd_header_as_string )`
- `write( filename )`
- `pMR.AcquisitionData('')` constructor with empty string
- `append_acquisition(Acquisition)`

This allows you to modify AcquisitionData objects from the Python layer.