### PR TITLE
MRAcq.Data Getter and Setter fail if not sorted

### DIFF
--- a/src/xGadgetron/cGadgetron/gadgetron_data_containers.cpp
+++ b/src/xGadgetron/cGadgetron/gadgetron_data_containers.cpp
@@ -596,7 +596,11 @@ AcquisitionsFile::items() const
 void 
 AcquisitionsFile::get_acquisition(unsigned int num, ISMRMRD::Acquisition& acq) const
 {
-	int ind = index(num);
+    unsigned int ind = num;
+
+    if(index_.size()>0)
+        ind = index_[num];
+
 	Mutex mtx;
 	mtx.lock();
 	dataset_->readAcquisition(ind, acq);

--- a/src/xGadgetron/cGadgetron/include/sirf/Gadgetron/gadgetron_data_containers.h
+++ b/src/xGadgetron/cGadgetron/include/sirf/Gadgetron/gadgetron_data_containers.h
@@ -361,12 +361,20 @@ namespace sirf {
 		}
 		virtual void get_acquisition(unsigned int num, ISMRMRD::Acquisition& acq) const
 		{
-			int ind = index(num);
+            unsigned int ind = num;
+
+            if(index_.size()>0)
+                ind = index_[num];
+
 			acq = *acqs_[ind];
 		}
 		virtual void set_acquisition(unsigned int num, ISMRMRD::Acquisition& acq)
 		{
-			int ind = index(num);
+            unsigned int ind = num;
+
+            if(index_.size()>0)
+                ind = index_[num];
+
 			*acqs_[ind] = acq;
 		}
 		virtual void copy_acquisitions_info(const MRAcquisitionData& ac)


### PR DESCRIPTION
since the index is accessed in the getter and setter, if not sorted there is nothing to access.

now just checks if index_ has size larger than zero, could be changed into checking for sorted() method also but then sort_by_time() does not set any boolean yet.