### PR TITLE
GadgetronImageData::set_meta_data to all set_up_geom_info

### DIFF
--- a/src/xGadgetron/cGadgetron/gadgetron_data_containers.cpp
+++ b/src/xGadgetron/cGadgetron/gadgetron_data_containers.cpp
@@ -1026,6 +1026,13 @@ GadgetronImageData::set_real_data(const float* z)
 	}
 }
 
+void
+GadgetronImageData::set_meta_data(const AcquisitionsInfo &acqs_info)
+{
+    acqs_info_ = acqs_info;
+    this->set_up_geom_info();
+}
+
 GadgetronImagesVector::GadgetronImagesVector
 (const GadgetronImagesVector& images) :
 images_()

--- a/src/xGadgetron/cGadgetron/include/sirf/Gadgetron/gadgetron_data_containers.h
+++ b/src/xGadgetron/cGadgetron/include/sirf/Gadgetron/gadgetron_data_containers.h
@@ -493,7 +493,7 @@ namespace sirf {
 				return i;
 		}
         /// Set the meta data
-        void set_meta_data(const AcquisitionsInfo &acqs_info) { acqs_info_ = acqs_info; }
+        void set_meta_data(const AcquisitionsInfo &acqs_info);
         /// Get the meta data
         const AcquisitionsInfo &get_meta_data() const { return acqs_info_; }
 


### PR DESCRIPTION
fixes #527. When setting meta data, make sure to call the `set_up_geom_info`.

@ckolbPTB Could you give this a go and let me know if it works for you? I managed to convert an MR reconstructed image to a `NiftiImageData`. 

(#532 enables `NiftiImageData(sirf.ImageData)` as well as `NiftiImageData3D(sirf.ImageData)`, which we discussed in the Hackathon.)