### PR TITLE
stir from nifti

### DIFF
--- a/src/Synergistic/tests/test_cSynergistic.cpp
+++ b/src/Synergistic/tests/test_cSynergistic.cpp
@@ -64,25 +64,22 @@ int main(int argc, char* argv[])
         if (argc > 2)
             mr_recon_h5_filename = argv[2];
 
-        // Test STIR -> Nifti
+        // Test Nifti -> STIR -> Nifti
         {
             std::cout << "\nPerforming STIRImageData to NiftiImageData conversion...\n";
 
             // Load the image as a NiftiImageData3D
             NiftiImageData3D<float> image_nifti(nifti_filename);
 
-            // Read as STIRImageData, convert NiftiImageData3D and save to file
-            STIRImageData image_stir(nifti_filename);
-            NiftiImageData3D<float> image_nifti_from_stir(image_stir);
-            image_nifti_from_stir.write("results/stir_to_nifti.nii",image_nifti.get_original_datatype());
+            // Convert to STIR
+            STIRImageData image_stir_from_nifti(image_nifti);
 
-            // Compare the two
-            if (image_nifti != image_nifti_from_stir)
-                throw std::runtime_error("Conversion from STIR to Nifti failed");
+            // Convert back to NiftiImageData3D
+            NiftiImageData3D<float> image_nifti_from_stir_from_nifti(image_stir_from_nifti);
 
-            // Also save the STIRImageData to file (might be useful visual for comparison)
-            create_stir_output_file_format("results/stir_output_file_format_nifti.par");
-            image_stir.write("results/stir.nii","results/stir_output_file_format_nifti.par");
+            // Compare Nifti's
+            if (image_nifti != image_nifti_from_stir_from_nifti)
+                throw std::runtime_error("Conversion Nifti->STIR->Nifti failed");
         }
 
         // Test Gadgetron -> Nifti

--- a/src/common/GeometricalInfo.cpp
+++ b/src/common/GeometricalInfo.cpp
@@ -20,6 +20,7 @@ limitations under the License.
 
 #include "sirf/common/GeometricalInfo.h"
 #include <iostream>
+#include <math.h>
 
 using namespace sirf;
 
@@ -46,6 +47,87 @@ print_info() const
         }
     }
     std::cout << "\n";
+}
+
+template <int num_dimensions>
+typename VoxelisedGeometricalInfo<num_dimensions>::Coordinate
+VoxelisedGeometricalInfo<num_dimensions>::
+multiply_by_direction_matrix(const DirectionMatrix &matrix, const Coordinate &input)
+{
+    Coordinate output = {0.f, 0.f, 0.f};
+    for (unsigned i=0; i<3; ++i)
+        for (unsigned j=0; j<3; ++j)
+            output[i] += matrix[i][j] * input[j];
+    return output;
+}
+
+template <int num_dimensions>
+typename VoxelisedGeometricalInfo<num_dimensions>::Index
+VoxelisedGeometricalInfo<num_dimensions>::
+multiply_by_direction_matrix(const DirectionMatrix &matrix, const Index &input)
+{
+    Coordinate temp = {0.f, 0.f, 0.f};
+    for (unsigned i=0; i<3; ++i)
+        for (unsigned j=0; j<3; ++j)
+            temp[i] += matrix[i][j] * input[j];
+    Index output = { unsigned(temp[0]),unsigned(temp[1]),unsigned(temp[2]) };
+    return output;
+}
+
+template <int num_dimensions>
+typename VoxelisedGeometricalInfo<num_dimensions>::DirectionMatrix
+VoxelisedGeometricalInfo<num_dimensions>::
+multiply_direction_matrices(const DirectionMatrix &input1, const DirectionMatrix &input2)
+{
+    DirectionMatrix output;
+    for (unsigned i=0; i<3; ++i)
+        for (unsigned j=0; j<3; ++j)
+            output[i][j] = 0.f;
+    for (unsigned i=0; i<3; ++i)
+        for (unsigned j=0; j<3; ++j)
+            for (unsigned k=0; k<3; ++k)
+                output[i][j] += input1[i][k] * input2[k][j];
+
+    return output;
+}
+
+template <int num_dimensions>
+typename VoxelisedGeometricalInfo<num_dimensions>::DirectionMatrix
+VoxelisedGeometricalInfo<num_dimensions>::
+inverse_direction_matrix(const DirectionMatrix &dm)
+{
+    DirectionMatrix output;
+
+    // computes the inverse of a matrix m
+    float det = dm[0][0] * (dm[1][1] * dm[2][2] - dm[2][1] * dm[1][2]) -
+                dm[0][1] * (dm[1][0] * dm[2][2] - dm[1][2] * dm[2][0]) +
+                dm[0][2] * (dm[1][0] * dm[2][1] - dm[1][1] * dm[2][0]);
+
+    float invdet = 1.f / det;
+
+    output[0][0] = (dm[1][1] * dm[2][2] - dm[2][1] * dm[1][2]) * invdet;
+    output[0][1] = (dm[0][2] * dm[2][1] - dm[0][1] * dm[2][2]) * invdet;
+    output[0][2] = (dm[0][1] * dm[1][2] - dm[0][2] * dm[1][1]) * invdet;
+    output[1][0] = (dm[1][2] * dm[2][0] - dm[1][0] * dm[2][2]) * invdet;
+    output[1][1] = (dm[0][0] * dm[2][2] - dm[0][2] * dm[2][0]) * invdet;
+    output[1][2] = (dm[1][0] * dm[0][2] - dm[0][0] * dm[1][2]) * invdet;
+    output[2][0] = (dm[1][0] * dm[2][1] - dm[2][0] * dm[1][1]) * invdet;
+    output[2][1] = (dm[2][0] * dm[0][1] - dm[0][0] * dm[2][1]) * invdet;
+    output[2][2] = (dm[0][0] * dm[1][1] - dm[1][0] * dm[0][1]) * invdet;
+
+    return output;
+}
+
+template <int num_dimensions>
+typename VoxelisedGeometricalInfo<num_dimensions>::DirectionMatrix
+VoxelisedGeometricalInfo<num_dimensions>::
+absolute_direction_matrix(const DirectionMatrix &dm)
+{
+    DirectionMatrix output;
+    for (unsigned i=0; i<4; ++i)
+        for (unsigned j=0; j<4; ++j)
+            output[i][j] = fabs(dm[i][j]);
+    return output;
 }
 
 template <int num_dimensions>

--- a/src/common/include/sirf/common/GeometricalInfo.h
+++ b/src/common/include/sirf/common/GeometricalInfo.h
@@ -91,6 +91,17 @@ public:
     /// Print info
     virtual void print_info() const;
 
+    /// Multiply coordinate by direction matrix
+    static Coordinate multiply_by_direction_matrix(const DirectionMatrix &matrix, const Coordinate &input);
+    /// Multiply index by direction matrix
+    static Index multiply_by_direction_matrix(const DirectionMatrix &matrix, const Index &input);
+    /// Multiply direction matrix by direction matrix
+    static DirectionMatrix multiply_direction_matrices(const DirectionMatrix &input1, const DirectionMatrix &input2);
+    /// Get inverse of direction matrix
+    static DirectionMatrix inverse_direction_matrix(const DirectionMatrix &dm);
+    /// Get absolute of direction matrix
+    static DirectionMatrix absolute_direction_matrix(const DirectionMatrix &dm);
+
 private:
 	Offset _offset;
 	Spacing _spacing;


### PR DESCRIPTION
Still in progress. 

@KrisThielemans We discussed calculating the transformation matrix and then converting each SIRF index into a STIR index, along the lines of:

https://github.com/rijobro/SIRF/blob/c8578ba65fb44eb95d324ba40a738d9651878ded/src/xSTIR/cSTIR/stir_data_containers.cpp#L360-L367

I realise that we can't access each element of the SIRFImageData individually, so this method won't work. Could we create a STIRImageData, fill it, and then reorient the image? I suppose my question is if there is reorient functionality in STIR?