### PR TITLE
method to reorient image

### DIFF
--- a/src/Registration/cReg/include/sirf/Reg/NiftiImageData.h
+++ b/src/Registration/cReg/include/sirf/Reg/NiftiImageData.h
@@ -594,6 +594,7 @@ protected:
         dim["w"] = d[7];
         return dim;
     }
+public:
     /// Set up the geometrical info. Use qform preferentially over sform.
     virtual void set_up_geom_info();
 protected:

--- a/src/common/+sirf/+SIRF/ImageData.m
+++ b/src/common/+sirf/+SIRF/ImageData.m
@@ -26,7 +26,7 @@ classdef ImageData < sirf.SIRF.DataContainer
 			geom_info.handle_ = calllib('msirf', 'mSIRF_ImageData_get_geom_info', self.handle_);
 		end
 		function reorient(self, geom_info)
-            % Reorient image. Requires that dimensions and spacing match.
+            % Reorient image. Requires that dimensions match.
             assert(isa(geom_info, 'sirf.SIRF.GeometricalInfo'));
             h = calllib('msirf', 'mSIRF_ImageData_reorient', self.handle_, geom_info.handle_);
             sirf.Utilities.check_status([self.name ':reorient'], h);

--- a/src/common/+sirf/+SIRF/ImageData.m
+++ b/src/common/+sirf/+SIRF/ImageData.m
@@ -25,5 +25,12 @@ classdef ImageData < sirf.SIRF.DataContainer
 			geom_info = sirf.SIRF.GeometricalInfo();
 			geom_info.handle_ = calllib('msirf', 'mSIRF_ImageData_get_geom_info', self.handle_);
 		end
+		function reorient(self, geom_info)
+            % Reorient image. Requires that dimensions and spacing match.
+            assert(isa(geom_info, 'sirf.SIRF.GeometricalInfo'));
+            h = calllib('msirf', 'mSIRF_ImageData_reorient', self.handle_, geom_info.handle_);
+            sirf.Utilities.check_status([self.name ':reorient'], h);
+            sirf.Utilities.delete(h)
+        end
 	end
 end

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -21,7 +21,7 @@ set(CMAKE_POSITION_INDEPENDENT_CODE True)
 
 set(cSIRF_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/include")
 
-add_library(csirf csirf.cpp GeometricalInfo.cpp)
+add_library(csirf csirf.cpp ImageData.cpp GeometricalInfo.cpp)
 target_include_directories(csirf PUBLIC
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>$<INSTALL_INTERFACE:include>"
   )

--- a/src/common/ImageData.cpp
+++ b/src/common/ImageData.cpp
@@ -1,0 +1,40 @@
+/*
+CCP PETMR Synergistic Image Reconstruction Framework (SIRF)
+Copyright 2020 University College London.
+
+This is software developed for the Collaborative Computational
+Project in Positron Emission Tomography and Magnetic Resonance imaging
+(http://www.ccppetmr.ac.uk/).
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
+#include "sirf/common/ImageData.h"
+
+using namespace sirf;
+
+void ImageData::reorient(const VoxelisedGeometricalInfo3D &)
+{
+    throw std::runtime_error("ImageData::reorient not yet implemented for your image type.");
+}
+
+bool ImageData::can_reorient(const VoxelisedGeometricalInfo3D &geom_1, const VoxelisedGeometricalInfo3D &geom_2, const bool throw_error)
+{
+    // If size and spacing match, return true
+    if (geom_1.get_size() == geom_2.get_size() && geom_1.get_spacing() == geom_2.get_spacing())
+        return true;
+    // Else (and error desired), print error
+    if (throw_error)
+        throw std::runtime_error("ImageData::can_reorient: num voxels or spacing do not match.");
+    // Else, return false
+    return false;
+}

--- a/src/common/ImageData.cpp
+++ b/src/common/ImageData.cpp
@@ -30,11 +30,11 @@ void ImageData::reorient(const VoxelisedGeometricalInfo3D &)
 bool ImageData::can_reorient(const VoxelisedGeometricalInfo3D &geom_1, const VoxelisedGeometricalInfo3D &geom_2, const bool throw_error)
 {
     // If size and spacing match, return true
-    if (geom_1.get_size() == geom_2.get_size() && geom_1.get_spacing() == geom_2.get_spacing())
+    if (geom_1.get_size() == geom_2.get_size())
         return true;
     // Else (and error desired), print error
     if (throw_error)
-        throw std::runtime_error("ImageData::can_reorient: num voxels or spacing do not match.");
+        throw std::runtime_error("ImageData::can_reorient: num voxels do not match.");
     // Else, return false
     return false;
 }

--- a/src/common/SIRF.py
+++ b/src/common/SIRF.py
@@ -490,7 +490,7 @@ class ImageData(DataContainer):
         return geom_info
 
     def reorient(self, geom_info):
-        """Reorient image. Requires that dimensions and spacing match."""
+        """Reorient image. Requires that dimensions match."""
         if not isinstance(geom_info, GeometricalInfo):
             raise AssertionError()
         try_calling(pysirf.cSIRF_ImageData_reorient(self.handle, geom_info.handle))

--- a/src/common/SIRF.py
+++ b/src/common/SIRF.py
@@ -489,6 +489,12 @@ class ImageData(DataContainer):
         check_status(geom_info.handle)
         return geom_info
 
+    def reorient(self, geom_info):
+        """Reorient image. Requires that dimensions and spacing match."""
+        if not isinstance(geom_info, GeometricalInfo):
+            raise AssertionError()
+        try_calling(pysirf.cSIRF_ImageData_reorient(self.handle, geom_info.handle))
+
 DataContainer.register(ImageData)
 
 class DataHandleVector(object):

--- a/src/common/csirf.cpp
+++ b/src/common/csirf.cpp
@@ -211,6 +211,19 @@ cSIRF_fillImageFromImage(void* ptr_im, const void* ptr_src)
 }
 
 extern "C"
+void* cSIRF_ImageData_reorient(void* im_ptr, void *geom_info_ptr)
+{
+    try {
+        ImageData& id = objectFromHandle<ImageData>(im_ptr);
+        VoxelisedGeometricalInfo3D geom_info =
+                objectFromHandle<VoxelisedGeometricalInfo3D>(geom_info_ptr);
+        id.reorient(geom_info);
+        return new DataHandle;
+    }
+    CATCH
+}
+
+extern "C"
 void*
 cSIRF_ImageData_get_geom_info(const void* ptr_im)
 {

--- a/src/common/include/sirf/common/ImageData.h
+++ b/src/common/include/sirf/common/ImageData.h
@@ -127,12 +127,15 @@ namespace sirf {
         }
         /// Is complex? Unless overwridden (Gadgetron), assume not complex.
         virtual bool is_complex() const { return false; }
-
+        /// Reorient image. Requires that dimesions and spacing match
+        virtual void reorient(const VoxelisedGeometricalInfo3D &);
+        /// Can reorient? (check dimensions and spacing)
+        static bool can_reorient(const VoxelisedGeometricalInfo3D &geom_1, const VoxelisedGeometricalInfo3D &geom_2, const bool throw_error);
+        /// Populate the geometrical info metadata (from the image's own metadata)
+        virtual void set_up_geom_info() = 0;
     protected:
         /// Clone helper function. Don't use.
         virtual ImageData* clone_impl() const = 0;
-        /// Populate the geometrical info metadata (from the image's own metadata)
-        virtual void set_up_geom_info() = 0;
         /// Set geom info
         void set_geom_info(const std::shared_ptr<VoxelisedGeometricalInfo3D> geom_info_sptr) { _geom_info_sptr = geom_info_sptr; }
     private:

--- a/src/common/include/sirf/common/csirf.h
+++ b/src/common/include/sirf/common/csirf.h
@@ -46,7 +46,9 @@ void* cSIRF_divide(const void* ptr_x, const void* ptr_y);
 void* cSIRF_write(const void* ptr, const char* filename);
 void* cSIRF_clone(void* ptr_x);
 
+// ImageData
 void* cSIRF_fillImageFromImage(void* ptr_im, const void* ptr_src);
+void* cSIRF_ImageData_reorient(void* im_ptr, void *geom_info_ptr);
 
 // DataHandleVector methods
 void* cSIRF_DataHandleVector_push_back(void* self, void* to_append);

--- a/src/common/msirf.c
+++ b/src/common/msirf.c
@@ -66,6 +66,9 @@ EXPORTED_FUNCTION void* mSIRF_clone(void* ptr_x) {
 EXPORTED_FUNCTION void* mSIRF_fillImageFromImage(void* ptr_im, const void* ptr_src) {
 	return cSIRF_fillImageFromImage(ptr_im, ptr_src);
 }
+EXPORTED_FUNCTION void* mSIRF_ImageData_reorient(void* im_ptr, void *geom_info_ptr) {
+	return cSIRF_ImageData_reorient(im_ptr, geom_info_ptr);
+}
 EXPORTED_FUNCTION void* mSIRF_DataHandleVector_push_back(void* self, void* to_append) {
 	return cSIRF_DataHandleVector_push_back(self, to_append);
 }

--- a/src/common/msirf.h
+++ b/src/common/msirf.h
@@ -45,6 +45,7 @@ EXPORTED_FUNCTION void* mSIRF_divide(const void* ptr_x, const void* ptr_y);
 EXPORTED_FUNCTION void* mSIRF_write(const void* ptr, const char* filename);
 EXPORTED_FUNCTION void* mSIRF_clone(void* ptr_x);
 EXPORTED_FUNCTION void* mSIRF_fillImageFromImage(void* ptr_im, const void* ptr_src);
+EXPORTED_FUNCTION void* mSIRF_ImageData_reorient(void* im_ptr, void *geom_info_ptr);
 EXPORTED_FUNCTION void* mSIRF_DataHandleVector_push_back(void* self, void* to_append);
 EXPORTED_FUNCTION void* mSIRF_ImageData_get_geom_info(const void* ptr_geom);
 EXPORTED_FUNCTION void* mSIRF_GeomInfo_print(const void* ptr_geom);

--- a/src/xGadgetron/cGadgetron/gadgetron_data_containers.cpp
+++ b/src/xGadgetron/cGadgetron/gadgetron_data_containers.cpp
@@ -1302,6 +1302,12 @@ void GadgetronImagesVector::reorient(const VoxelisedGeometricalInfo3D &geom_info
             ih.slice_dir[axis] = -direction[axis][2];
         }
 
+        // FOV
+        auto spacing = geom_info_out.get_spacing();
+        auto size = geom_info_out.get_size();
+        for(unsigned i=0; i<3; ++i)
+            ih.field_of_view[i] = spacing[i] * size[i];
+
         // Position
         auto offset = geom_info_out.get_offset();
         for (unsigned i=0; i<3; ++i)

--- a/src/xGadgetron/cGadgetron/include/sirf/Gadgetron/gadgetron_data_containers.h
+++ b/src/xGadgetron/cGadgetron/include/sirf/Gadgetron/gadgetron_data_containers.h
@@ -787,7 +787,9 @@ namespace sirf {
         /// Is complex?
         virtual bool is_complex() const;
 
-    protected:
+        /// Reorient image. Requires that dimensions and spacing match
+        virtual void reorient(const VoxelisedGeometricalInfo3D &geom_info_out);
+
         /// Populate the geometrical info metadata (from the image's own metadata)
         virtual void set_up_geom_info();
 

--- a/src/xGadgetron/cGadgetron/include/sirf/Gadgetron/gadgetron_data_containers.h
+++ b/src/xGadgetron/cGadgetron/include/sirf/Gadgetron/gadgetron_data_containers.h
@@ -787,7 +787,7 @@ namespace sirf {
         /// Is complex?
         virtual bool is_complex() const;
 
-        /// Reorient image. Requires that dimensions and spacing match
+        /// Reorient image. Requires that dimensions match
         virtual void reorient(const VoxelisedGeometricalInfo3D &geom_info_out);
 
         /// Populate the geometrical info metadata (from the image's own metadata)

--- a/src/xSTIR/cSTIR/include/sirf/STIR/stir_data_containers.h
+++ b/src/xSTIR/cSTIR/include/sirf/STIR/stir_data_containers.h
@@ -760,6 +760,9 @@ namespace sirf {
         /// bed offset etc can be taken into account.
         void move_to_scanner_centre(const PETAcquisitionData &);
 
+        /// Populate the geometrical info metadata (from the image's own metadata)
+        virtual void set_up_geom_info();
+
     private:
         /// Clone helper function. Don't use.
         virtual STIRImageData* clone_impl() const
@@ -768,9 +771,6 @@ namespace sirf {
         }
 
 	protected:
-
-        /// Populate the geometrical info metadata (from the image's own metadata)
-        virtual void set_up_geom_info();
 
 		stir::shared_ptr<Image3DF> _data;
 		mutable stir::shared_ptr<Iterator> _begin;


### PR DESCRIPTION
requires that dimensions of image matches that of desired `VoxelisedGeometricalinfo`. if so, modify spacing, offset and direction matrix such that image matches geom info. 

Modify the "native" geometrical info (e.g., the `ISMRMRD::header` and then run SIRF's `set_up_geom_info()`. If the native info has been correctly set, then the output of the `set_up_geom_info()` should match that of the desired input. This is a good sanity check.

Currently only implemented for Gadgetron (although would be trivial for `NiftiImageData`. Exported to C++, matlab and python