### PR TITLE
Sorting kspace

### DIFF
--- a/src/xGadgetron/cGadgetron/CMakeLists.txt
+++ b/src/xGadgetron/cGadgetron/CMakeLists.txt
@@ -70,3 +70,5 @@ endif()
 target_link_libraries(cgadgetron ${ismrmrd_full_path})
 target_link_libraries(cgadgetron "${FFTW3_LIBRARIES}")
 target_link_libraries(cgadgetron "${HDF5_LIBRARIES}")
+
+ADD_SUBDIRECTORY(tests)

--- a/src/xGadgetron/cGadgetron/CMakeLists.txt
+++ b/src/xGadgetron/cGadgetron/CMakeLists.txt
@@ -44,7 +44,7 @@ target_include_directories(cgadgetron PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_
 
 target_include_directories(cgadgetron PUBLIC "${cGadgetron_INCLUDE_DIR}")
 target_include_directories(cgadgetron PRIVATE "${FFTW3_INCLUDE_DIR}")
-target_include_directories(cgadgetron PRIVATE "${ISMRMRD_INCLUDE_DIR}")
+target_include_directories(cgadgetron PUBLIC "${ISMRMRD_INCLUDE_DIR}")
 
 target_link_libraries(cgadgetron iutilities csirf)
 # Add boost library dependencies

--- a/src/xGadgetron/cGadgetron/gadgetron_data_containers.cpp
+++ b/src/xGadgetron/cGadgetron/gadgetron_data_containers.cpp
@@ -557,6 +557,7 @@ MRAcquisitionData::sort()
 
 	index_.resize(na);
 	NewMultisort::sort( vt, &index_[0] );
+    this->organise_kspace();
 	sorted_ = true;
 }
 
@@ -582,7 +583,120 @@ MRAcquisitionData::sort_by_time()
 		std::cerr << "WARNING: You try to sort by time an empty container of acquisition data." << std::endl;
 	else
 		Multisort::sort( vt, &index_[0] );
+    this->organise_kspace();
 
+}
+
+std::vector<std::vector<int> > MRAcquisitionData::get_kspace_order(bool get_first_subset_order)
+{
+    if(this->sorting_.size() == 0)
+        throw LocalisedException("The kspace is not sorted yet. Please call organise_kspace(), sort() or sort_by_time() first." , __FILE__, __LINE__);
+
+    std::vector<std::vector<int>> output;
+    for(int i = 0; i<sorting_.size(); ++i)
+    {
+        if(!get_first_subset_order)
+        {
+            if(sorting_.at(i).get_set().size()>0)
+               output.push_back(sorting_.at(i).get_set());
+        }
+        else
+            if(sorting_.at(i).is_first_set() && sorting_.at(i).get_set().size()>0)
+                output.push_back(sorting_.at(i).get_set());
+    }
+    return output;
+}
+
+static int get_num_enc_states( const ISMRMRD::Optional<ISMRMRD::Limit>& enc_lim)
+{
+	int num_states =1;
+
+	if(enc_lim.is_present())
+	{
+	    ISMRMRD::Limit lim = enc_lim.get();
+		num_states = lim.maximum - lim.minimum +1;
+	}
+
+	return num_states;
+}
+
+void MRAcquisitionData::organise_kspace()
+{
+    ISMRMRD::IsmrmrdHeader header;
+    ISMRMRD::deserialize(this->acqs_info_.c_str(), header);
+
+    auto encoding_vector = header.encoding;
+
+    if(encoding_vector.size()>1)
+        throw LocalisedException("Curerntly only one encoding is supported. You supplied multiple in one ismrmrd file.", __FUNCTION__, __LINE__);
+
+    ISMRMRD::Encoding encoding = encoding_vector[0];
+    ISMRMRD::EncodingLimits enc_lims = encoding.encodingLimits;
+
+    int NAvg    = get_num_enc_states(enc_lims.average); 
+    int NSlice  = get_num_enc_states(enc_lims.slice); 
+    int NCont   = get_num_enc_states(enc_lims.contrast);
+    int NPhase  = get_num_enc_states(enc_lims.phase); 
+    int NRep    = get_num_enc_states(enc_lims.repetition);
+    int NSet    = get_num_enc_states(enc_lims.set);
+    int NSegm = 1; // lim_segm.maximum    - lim_segm.minimum +1; // this has no correspondence in the header of the image of course. currently no sorting wrt to this
+
+    for(int ia= 0; ia <NAvg; ia++)
+    for(int is= 0; is <NSlice; is++)
+    for(int ic= 0; ic <NCont; ic++)
+    for(int ip= 0; ip <NPhase; ip++)
+    for(int ir= 0; ir <NRep; ir++)
+    for(int iset= 0; iset <NSet; iset++)
+    for(int iseg=0;   iseg<NSegm; ++iseg)
+    {
+        KSpaceSorting::TagType tag{ia, is, ic, ip, ir, iset, iseg};
+        for(int i=7; i<tag.size(); ++i)
+            tag[i]=0; // ignore user ints so far
+
+        KSpaceSorting sorting(tag);
+        this->sorting_.push_back(sorting);
+    }
+
+    int num_total_sets = NAvg*NSlice*NCont*NPhase*NRep*NSet*NSegm;
+    std::vector<std::vector<int> > sorted_idx;
+
+    ISMRMRD::Acquisition acq;
+    for(int i=0; i<this->number(); ++i)
+    {
+        this->get_acquisition(i, acq);
+
+        KSpaceSorting::TagType tag = KSpaceSorting::get_tag_from_acquisition(acq);
+        int access_idx = (((((tag[0] * NSlice + tag[1])*NCont + tag[2])*NPhase + tag[3])*NRep + tag[4])*NSet + tag[5])*NSegm + tag[6];
+        this->sorting_.at(access_idx).add_idx_to_set(i);
+    }
+}
+
+void MRAcquisitionData::get_subset(MRAcquisitionData& subset, std::vector<int> subset_idx)
+{
+    subset.set_acquisitions_info(this->acquisitions_info());
+
+    if(subset.number()>0)
+        throw LocalisedException("Please pass an empty MRAcquisitionnData container to store the subset in", __FUNCTION__, __LINE__);
+
+    ISMRMRD::Acquisition acq;
+    for(int i=0; i<subset_idx.size(); ++i)
+    {
+        this->get_acquisition(subset_idx[i], acq);
+        subset.append_acquisition(acq);
+    }
+}
+
+void MRAcquisitionData::set_subset(MRAcquisitionData& subset, std::vector<int> subset_idx)
+{
+    if(subset.number() != subset_idx.size())
+        throw LocalisedException("Number of subset positions and number of acquisitions in subset don't match.", __FILE__, __LINE__);
+
+    ISMRMRD::Acquisition acq;
+    for(int i=0; i<subset_idx.size(); ++i)
+    {
+        subset.get_acquisition(i, acq);
+        this->set_acquisition(subset_idx[i], acq);
+    }
 }
 
 AcquisitionsFile::AcquisitionsFile

--- a/src/xGadgetron/cGadgetron/gadgetron_data_containers.cpp
+++ b/src/xGadgetron/cGadgetron/gadgetron_data_containers.cpp
@@ -587,22 +587,22 @@ MRAcquisitionData::sort_by_time()
 
 }
 
-std::vector<std::vector<int> > MRAcquisitionData::get_kspace_order(bool get_first_subset_order)
+std::vector<std::vector<int> > MRAcquisitionData::get_kspace_order(const bool get_first_subset_order) const
 {
     if(this->sorting_.size() == 0)
         throw LocalisedException("The kspace is not sorted yet. Please call organise_kspace(), sort() or sort_by_time() first." , __FILE__, __LINE__);
 
-    std::vector<std::vector<int>> output;
-    for(int i = 0; i<sorting_.size(); ++i)
+    std::vector<std::vector<int> > output;
+    for(unsigned i = 0; i<sorting_.size(); ++i)
     {
         if(!get_first_subset_order)
         {
-            if(sorting_.at(i).get_set().size()>0)
-               output.push_back(sorting_.at(i).get_set());
+            if(!sorting_.at(i).get_idx_set().empty())
+               output.push_back(sorting_.at(i).get_idx_set());
         }
         else
-            if(sorting_.at(i).is_first_set() && sorting_.at(i).get_set().size()>0)
-                output.push_back(sorting_.at(i).get_set());
+            if(sorting_.at(i).is_first_set() && !sorting_.at(i).get_idx_set().empty())
+                output.push_back(sorting_.at(i).get_idx_set());
     }
     return output;
 }
@@ -657,9 +657,6 @@ void MRAcquisitionData::organise_kspace()
         this->sorting_.push_back(sorting);
     }
 
-    int num_total_sets = NAvg*NSlice*NCont*NPhase*NRep*NSet*NSegm;
-    std::vector<std::vector<int> > sorted_idx;
-
     ISMRMRD::Acquisition acq;
     for(int i=0; i<this->number(); ++i)
     {
@@ -671,7 +668,7 @@ void MRAcquisitionData::organise_kspace()
     }
 }
 
-void MRAcquisitionData::get_subset(MRAcquisitionData& subset, std::vector<int> subset_idx)
+void MRAcquisitionData::get_subset(MRAcquisitionData& subset, const std::vector<int> subset_idx) const
 {
     subset.set_acquisitions_info(this->acquisitions_info());
 
@@ -686,7 +683,7 @@ void MRAcquisitionData::get_subset(MRAcquisitionData& subset, std::vector<int> s
     }
 }
 
-void MRAcquisitionData::set_subset(MRAcquisitionData& subset, std::vector<int> subset_idx)
+void MRAcquisitionData::set_subset(const MRAcquisitionData& subset, const std::vector<int> subset_idx)
 {
     if(subset.number() != subset_idx.size())
         throw LocalisedException("Number of subset positions and number of acquisitions in subset don't match.", __FILE__, __LINE__);

--- a/src/xGadgetron/cGadgetron/include/sirf/Gadgetron/gadgetron_data_containers.h
+++ b/src/xGadgetron/cGadgetron/include/sirf/Gadgetron/gadgetron_data_containers.h
@@ -142,7 +142,7 @@ namespace sirf {
         }
 
         TagType get_tag(void) const {return tag_;}
-        SetType get_set(void) const {return idx_set_;}
+        SetType get_idx_set(void) const {return idx_set_;}
         void add_idx_to_set(size_t const idx){this->idx_set_.push_back(idx);}
 
         static TagType get_tag_from_acquisition(ISMRMRD::Acquisition acq)
@@ -272,11 +272,11 @@ namespace sirf {
 		bool sorted() const { return sorted_; }
 		void set_sorted(bool sorted) { sorted_ = sorted; }
 
-        std::vector<std::vector<int> > get_kspace_order(bool const get_first_subset_order=false);
+        std::vector<std::vector<int> > get_kspace_order(const bool get_first_subset_order=false) const;
         void organise_kspace();
 
-        virtual void get_subset(MRAcquisitionData& subset, std::vector<int> subset_idx);
-        virtual void set_subset(MRAcquisitionData& subset, std::vector<int> subset_idx);
+        virtual void get_subset(MRAcquisitionData& subset, const std::vector<int> subset_idx) const;
+        virtual void set_subset(const MRAcquisitionData &subset, const std::vector<int> subset_idx);
 
 		std::vector<int> index() { return index_; }
 		const std::vector<int>& index() const { return index_; }

--- a/src/xGadgetron/cGadgetron/include/sirf/Gadgetron/gadgetron_data_containers.h
+++ b/src/xGadgetron/cGadgetron/include/sirf/Gadgetron/gadgetron_data_containers.h
@@ -117,6 +117,69 @@ namespace sirf {
 		bool have_header_;
 	};
 
+    class KSpaceSorting
+    {
+        static int const num_kspace_dims_ = 7 + ISMRMRD::ISMRMRD_Constants::ISMRMRD_USER_INTS;
+
+    public:
+
+        typedef std::array<int, num_kspace_dims_> TagType;
+        typedef std::vector<int> SetType;
+
+        KSpaceSorting(){
+            for(int i=0; i<num_kspace_dims_; ++i)
+                this->tag_[i] = -1;
+        }
+
+        KSpaceSorting(TagType tag){
+            this->tag_ = tag;
+            this->idx_set_ = {};
+        }
+
+        KSpaceSorting(TagType tag, SetType idx_set){
+            this->tag_ = tag;
+            this->idx_set_ = idx_set;
+        }
+
+        TagType get_tag(void) const {return tag_;}
+        SetType get_set(void) const {return idx_set_;}
+        void add_idx_to_set(size_t const idx){this->idx_set_.push_back(idx);}
+
+        static TagType get_tag_from_acquisition(ISMRMRD::Acquisition acq)
+        {
+            TagType tag;
+            tag[0] = acq.idx().average;
+            tag[1] = acq.idx().slice;
+            tag[2] = acq.idx().contrast;
+            tag[3] = acq.idx().phase;
+            tag[4] = acq.idx().repetition;
+            tag[5] = acq.idx().set;
+            tag[6] = 0; //acq.idx().segment;
+
+            for(int i=7; i<tag.size(); ++i)
+                tag[i]=acq.idx().user[i];
+
+            return tag;
+        }
+
+        bool is_first_set() const {
+            bool is_first= (tag_[0] == 0);
+            if(is_first)
+            {
+               for(int dim=2; dim<num_kspace_dims_; ++dim)
+                   is_first *= (tag_[dim] == 0);
+            }
+            return is_first;
+        }
+
+    private:
+
+        // order is [average, slice, contrast, phase, repetition, set, segment, user_ (0,...,ISMRMRD_USER_INTS-1)]
+        TagType tag_;
+        SetType idx_set_;
+
+    };
+
 	/*!
 	\ingroup Gadgetron Data Containers
 	\brief Abstract MR acquisition data container class.
@@ -209,6 +272,12 @@ namespace sirf {
 		bool sorted() const { return sorted_; }
 		void set_sorted(bool sorted) { sorted_ = sorted; }
 
+        std::vector<std::vector<int> > get_kspace_order(bool const get_first_subset_order=false);
+        void organise_kspace();
+
+        virtual void get_subset(MRAcquisitionData& subset, std::vector<int> subset_idx);
+        virtual void set_subset(MRAcquisitionData& subset, std::vector<int> subset_idx);
+
 		std::vector<int> index() { return index_; }
 		const std::vector<int>& index() const { return index_; }
 
@@ -237,6 +306,7 @@ namespace sirf {
 	protected:
 		bool sorted_=false;
 		std::vector<int> index_;
+        std::vector<KSpaceSorting> sorting_;
 		AcquisitionsInfo acqs_info_;
 
 		static std::string _storage_scheme;
@@ -449,11 +519,11 @@ namespace sirf {
 			dim["n"] = number();
 			return dim;
 		}
-		virtual void get_image_dimensions(unsigned int im_num, int* dim)
+        virtual void get_image_dimensions(unsigned int im_num, int* dim) const
 		{
 			if (im_num >= number())
 				dim[0] = dim[1] = dim[2] = dim[3] = 0;
-			ImageWrap& iw = image_wrap(im_num);
+            const ImageWrap&  iw = image_wrap(im_num);
 			iw.get_dim(dim);
 		}
 		virtual gadgetron::shared_ptr<ISMRMRDImageData> 

--- a/src/xGadgetron/cGadgetron/tests/CMakeLists.txt
+++ b/src/xGadgetron/cGadgetron/tests/CMakeLists.txt
@@ -17,10 +17,10 @@
 #
 #=========================================================================
 
-add_executable(MR_TEST_CPLUSPLUS ${CMAKE_CURRENT_SOURCE_DIR}/mrtests.cpp)
-target_link_libraries(MR_TEST_CPLUSPLUS PUBLIC csirf cgadgetron)
-INSTALL(TARGETS MR_TEST_CPLUSPLUS DESTINATION bin)
+add_executable(MR_TESTS_CPLUSPLUS ${CMAKE_CURRENT_SOURCE_DIR}/mrtests.cpp)
+target_link_libraries(MR_TESTS_CPLUSPLUS PUBLIC csirf cgadgetron)
+INSTALL(TARGETS MR_TESTS_CPLUSPLUS DESTINATION bin)
 
-ADD_TEST(NAME MR_TEST_CPLUSPLUS
-         COMMAND MR_TEST_CPLUSPLUS
+ADD_TEST(NAME MR_TESTS_CPLUSPLUS
+         COMMAND MR_TESTS_CPLUSPLUS
          WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})

--- a/src/xGadgetron/cGadgetron/tests/CMakeLists.txt
+++ b/src/xGadgetron/cGadgetron/tests/CMakeLists.txt
@@ -1,0 +1,26 @@
+#========================================================================
+# Author: Johannes Mayer
+# Copyright 2016 University College London
+# Copyright 2020 Physikalisch-Technische Bundesanstalt Berlin
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0.txt
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+#=========================================================================
+
+add_executable(MR_TEST_CPLUSPLUS ${CMAKE_CURRENT_SOURCE_DIR}/mrtests.cpp)
+target_link_libraries(MR_TEST_CPLUSPLUS PUBLIC csirf cgadgetron)
+INSTALL(TARGETS MR_TEST_CPLUSPLUS DESTINATION bin)
+
+ADD_TEST(NAME MR_TEST_CPLUSPLUS
+         COMMAND MR_TEST_CPLUSPLUS
+         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})

--- a/src/xGadgetron/cGadgetron/tests/mrtests.cpp
+++ b/src/xGadgetron/cGadgetron/tests/mrtests.cpp
@@ -25,7 +25,7 @@ bool test_get_kspace_order(const std::string& fname_input)
     {
         std::cout << "Exception caught " <<__FUNCTION__ <<" .!" <<std::endl;
         std::cout << e.what() << std::endl;
-        throw e;
+        throw;
     }
 }
 
@@ -52,7 +52,7 @@ bool test_get_subset(const std::string& fname_input)
     {
         std::cout << "Exception caught " <<__FUNCTION__ <<" .!" <<std::endl;
         std::cout << e.what() << std::endl;
-        throw e;
+        throw;
     }
 }
 

--- a/src/xGadgetron/cGadgetron/tests/mrtests.cpp
+++ b/src/xGadgetron/cGadgetron/tests/mrtests.cpp
@@ -1,40 +1,16 @@
 #include <iostream>
 #include <cstdlib>
 
-#include "mrtest_auxiliary_funs.h"
-
-#include "sirf/Gadgetron/encoding.h"
 #include "sirf/Gadgetron/gadgetron_data_containers.h"
 #include "sirf/Gadgetron/gadgetron_x.h"
-#include "sirf/Gadgetron/gadget_lib.h"
 
 using namespace sirf;
 
-bool test_get_kspace_order(void)
+bool test_get_kspace_order(const std::string& fname_input)
 {
     try
     {
         std::cout << "Running test " << __FUNCTION__ << std::endl;
-
-        std::string const fpath_input = "/media/sf_CCPPETMR/TestData/Input/xGadgetron/cGadgetron/";
-        std::string fname_input = fpath_input + "CV_SR_64Cube_1Echo_10Dyn.h5";
-
-        sirf::AcquisitionsVector av;
-        av.read(fname_input);
-        av.sort();
-
-        auto kspace_sorting = av.get_kspace_order();
-
-        fname_input = fpath_input + "CV_SR_128Cube_1Echo_3Dyn.h5";
-
-        sirf::AcquisitionsVector av_contrast;
-        av_contrast.read(fname_input);
-        av_contrast.sort();
-
-        auto kspace_sorting_contrast = av_contrast.get_kspace_order();
-
-
-        fname_input = fpath_input + "CV_2D_Stack_144.h5";
 
         sirf::AcquisitionsVector av_slice;
         av_slice.read(fname_input);
@@ -53,14 +29,11 @@ bool test_get_kspace_order(void)
     }
 }
 
-bool test_get_subset()
+bool test_get_subset(const std::string& fname_input)
 {
     try
     {
         std::cout << "Running test " << __FUNCTION__ << std::endl;
-
-        std::string const fpath_input = "/media/sf_CCPPETMR/TestData/Input/xGadgetron/cGadgetron/";
-        std::string fname_input = fpath_input + "CV_SR_64Cube_1Echo_10Dyn.h5";
 
         sirf::AcquisitionsVector av;
         av.read(fname_input);
@@ -83,12 +56,21 @@ bool test_get_subset()
     }
 }
 
-int main ()
+int main ( int argc, char* argv[])
 {
+
 	try{
 
-       test_get_kspace_order();
-       test_get_subset();
+        std::string SIRF_PATH;
+        if (argc==1)
+            SIRF_PATH = getenv("SIRF_PATH");
+        else
+            SIRF_PATH = argv[1];
+
+        std::string data_path = SIRF_PATH + "/data/examples/MR/simulated_MR_2D_cartesian_Grappa2.h5";
+
+        test_get_kspace_order(data_path);
+        test_get_subset(data_path);
         return 0;
 	}
     catch(const std::exception &error) {

--- a/src/xGadgetron/cGadgetron/tests/mrtests.cpp
+++ b/src/xGadgetron/cGadgetron/tests/mrtests.cpp
@@ -1,0 +1,100 @@
+#include <iostream>
+#include <cstdlib>
+
+#include "mrtest_auxiliary_funs.h"
+
+#include "sirf/Gadgetron/encoding.h"
+#include "sirf/Gadgetron/gadgetron_data_containers.h"
+#include "sirf/Gadgetron/gadgetron_x.h"
+#include "sirf/Gadgetron/gadget_lib.h"
+
+using namespace sirf;
+
+bool test_get_kspace_order(void)
+{
+    try
+    {
+        std::cout << "Running test " << __FUNCTION__ << std::endl;
+
+        std::string const fpath_input = "/media/sf_CCPPETMR/TestData/Input/xGadgetron/cGadgetron/";
+        std::string fname_input = fpath_input + "CV_SR_64Cube_1Echo_10Dyn.h5";
+
+        sirf::AcquisitionsVector av;
+        av.read(fname_input);
+        av.sort();
+
+        auto kspace_sorting = av.get_kspace_order();
+
+        fname_input = fpath_input + "CV_SR_128Cube_1Echo_3Dyn.h5";
+
+        sirf::AcquisitionsVector av_contrast;
+        av_contrast.read(fname_input);
+        av_contrast.sort();
+
+        auto kspace_sorting_contrast = av_contrast.get_kspace_order();
+
+
+        fname_input = fpath_input + "CV_2D_Stack_144.h5";
+
+        sirf::AcquisitionsVector av_slice;
+        av_slice.read(fname_input);
+        av_slice.sort();
+
+        auto kspace_sorting_slice = av_slice.get_kspace_order();
+
+        return true;
+
+    }
+    catch( std::runtime_error const &e)
+    {
+        std::cout << "Exception caught " <<__FUNCTION__ <<" .!" <<std::endl;
+        std::cout << e.what() << std::endl;
+        throw e;
+    }
+}
+
+bool test_get_subset()
+{
+    try
+    {
+        std::cout << "Running test " << __FUNCTION__ << std::endl;
+
+        std::string const fpath_input = "/media/sf_CCPPETMR/TestData/Input/xGadgetron/cGadgetron/";
+        std::string fname_input = fpath_input + "CV_SR_64Cube_1Echo_10Dyn.h5";
+
+        sirf::AcquisitionsVector av;
+        av.read(fname_input);
+
+        std::vector<int> subset_idx;
+        for(int i=0; i<av.number()/10; ++i)
+            subset_idx.push_back(i);
+
+        sirf::AcquisitionsVector subset;
+        av.get_subset(subset, subset_idx);
+
+        return true;
+
+    }
+    catch( std::runtime_error const &e)
+    {
+        std::cout << "Exception caught " <<__FUNCTION__ <<" .!" <<std::endl;
+        std::cout << e.what() << std::endl;
+        throw e;
+    }
+}
+
+int main ()
+{
+	try{
+
+       test_get_kspace_order();
+       test_get_subset();
+        return 0;
+	}
+    catch(const std::exception &error) {
+        std::cerr << "\nHere's the error:\n\t" << error.what() << "\n\n";
+        return EXIT_FAILURE;
+    }
+    return EXIT_SUCCESS;
+}
+


### PR DESCRIPTION
Enabled testing for MR on C++ level.

Added feature to sort kspace data based on its encoding counter index.
This way it is not necessary to sort the data into a 16 dimensional array, but rather we keep track of which acquisitions belong into which bin.