### PR TITLE
allow resampling with different sized grids to reference image

### DIFF
--- a/src/Registration/cReg/NiftiImageData3DDeformation.cpp
+++ b/src/Registration/cReg/NiftiImageData3DDeformation.cpp
@@ -69,8 +69,23 @@ void NiftiImageData3DDeformation<dataType>::create_from_cpp(NiftiImageData3DTens
 template<class dataType>
 NiftiImageData3DDeformation<dataType> NiftiImageData3DDeformation<dataType>::get_as_deformation_field(const NiftiImageData<dataType> &ref) const
 {
-    this->check_ref_and_def(ref,*this);
-    return *this;
+    NiftiImageData3DDeformation<dataType> output_def;
+    output_def.create_from_3D_image(ref);
+    nifti_image * def_ptr = output_def.get_raw_nifti_sptr().get();
+
+    // Initialise the deformation field with an identity transformation
+    reg_tools_multiplyValueToImage(def_ptr,def_ptr,0.f);
+    reg_getDeformationFromDisplacement(def_ptr);
+    def_ptr->intent_p1=DEF_FIELD;
+
+    // Not marked const so have to copy unfortunately
+    std::shared_ptr<NiftiImageData3DDeformation<dataType> > copy_of_input_def_sptr =
+            this->clone();
+
+    reg_defField_compose(copy_of_input_def_sptr->get_raw_nifti_sptr().get(),
+                         def_ptr,
+                         nullptr);
+    return output_def;
 }
 
 template<class dataType>


### PR DESCRIPTION
fixes #508
resamples now match that of `reg_resample`, even when displacement/deformation field does not match reference image.