### PR TITLE
matlab: fix libstd++ version differences on linux

### DIFF
--- a/src/Registration/CMakeLists.txt
+++ b/src/Registration/CMakeLists.txt
@@ -23,6 +23,8 @@ if (BUILD_MATLAB)
 		list(APPEND Matlab_LIBRARIES 
 			"${Matlab_ROOT_DIR}/extern/bin/glnxa64/libMatlabEngine.so" 
 			"${Matlab_ROOT_DIR}/extern/bin/glnxa64/libMatlabDataArray.so")
+		# Account for potential mismatch between libstdc++ for compilation and Matlab's
+		set(CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} -static-libstdc++)
 	endif()
 
 	find_package(SPM QUIET)


### PR DESCRIPTION
version of libstdc++ used to compile .mex files and Matlab's version libstdc++ aren't necessarily the same, causing problems at runtime. Simple answer is to link statically against libstdc++