### PR TITLE
HDF5 matlab fix

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -29,8 +29,6 @@ option(DISABLE_Gadgetron "Disable building the SIRF interface to Gadgetron" OFF)
 if (DISABLE_Gadgetron)
   message(STATUS "Gadgetron support disabled.")
 else()
-  # include explicit search for HDF5 for older ISMRMRD versions.
-  find_package(HDF5 1.8 COMPONENTS C REQUIRED)
   find_package(ISMRMRD REQUIRED)
   # Add ISMRMRD to search path for FFTW3
   set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH};${ISMRMRD_DIR}")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -29,7 +29,7 @@ option(DISABLE_Gadgetron "Disable building the SIRF interface to Gadgetron" OFF)
 if (DISABLE_Gadgetron)
   message(STATUS "Gadgetron support disabled.")
 else()
-  find_package(ISMRMRD 1.4.1 REQUIRED)
+  find_package(ISMRMRD 1.4 REQUIRED)
   # Add ISMRMRD to search path for FFTW3
   set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH};${ISMRMRD_DIR}")
   find_package(FFTW3 COMPONENTS single REQUIRED)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -29,7 +29,7 @@ option(DISABLE_Gadgetron "Disable building the SIRF interface to Gadgetron" OFF)
 if (DISABLE_Gadgetron)
   message(STATUS "Gadgetron support disabled.")
 else()
-  find_package(ISMRMRD REQUIRED)
+  find_package(ISMRMRD 1.4.1 REQUIRED)
   # Add ISMRMRD to search path for FFTW3
   set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH};${ISMRMRD_DIR}")
   find_package(FFTW3 COMPONENTS single REQUIRED)

--- a/src/xGadgetron/cGadgetron/CMakeLists.txt
+++ b/src/xGadgetron/cGadgetron/CMakeLists.txt
@@ -46,29 +46,36 @@ target_include_directories(cgadgetron PUBLIC "${cGadgetron_INCLUDE_DIR}")
 target_include_directories(cgadgetron PRIVATE "${FFTW3_INCLUDE_DIR}")
 target_include_directories(cgadgetron PUBLIC "${ISMRMRD_INCLUDE_DIR}")
 
-target_link_libraries(cgadgetron iutilities csirf)
+target_link_libraries(cgadgetron PUBLIC iutilities csirf)
 # Add boost library dependencies
 if((CMAKE_VERSION VERSION_LESS 3.5.0) OR (NOT _Boost_IMPORTED_TARGETS))
   # This is harder than it should be on older CMake versions to be able to cope with
   # spaces in filenames.
   foreach(C SYSTEM FILESYSTEM THREAD DATE_TIME CHRONO)
-    target_link_libraries(cgadgetron optimized "${Boost_${C}_LIBRARY_RELEASE}")
-    target_link_libraries(cgadgetron debug  "${Boost_${C}_LIBRARY_DEBUG}")
+    target_link_libraries(cgadgetron PUBLIC optimized "${Boost_${C}_LIBRARY_RELEASE}")
+    target_link_libraries(cgadgetron PUBLIC debug  "${Boost_${C}_LIBRARY_DEBUG}")
   endforeach()
 else()
   # Nice and simple for recent CMake (which knows about your Boost version)
-  target_link_libraries(cgadgetron Boost::system Boost::filesystem Boost::thread Boost::date_time Boost::chrono)
+  target_link_libraries(cgadgetron PUBLIC Boost::system Boost::filesystem Boost::thread Boost::date_time Boost::chrono)
 endif()
 
 # Note: cannot use ISMRMRD_LIBRARIES on Windows as it generally contains 
 # a list of filenames with spaces. There doesn't seem to be a way to pass this through (strange).
 # Luckily, we know what libraries it uses
-find_library(ismrmrd_full_path "ismrmrd" "${ISMRMRD_LIBRARY_DIRS}")
-if(NOT ismrmrd_full_path)
-  message(FATAL_ERROR "ismrmrd not found")
+if (WIN32)
+  find_library(ismrmrd_full_path "ismrmrd" "${ISMRMRD_LIBRARY_DIRS}")
+  if(NOT ismrmrd_full_path)
+    message(FATAL_ERROR "ismrmrd not found")
+  endif()
+  find_package(HDF5 COMPONENTS C REQUIRED)
+  target_link_libraries(cgadgetron PUBLIC "${ismrmrd_full_path}")
+  target_link_libraries(cgadgetron PUBLIC "${HDF5_LIBRARIES}")
+else()
+  target_link_libraries(cgadgetron PUBLIC ISMRMRD::ISMRMRD)
 endif()
-target_link_libraries(cgadgetron ${ismrmrd_full_path})
-target_link_libraries(cgadgetron "${FFTW3_LIBRARIES}")
-target_link_libraries(cgadgetron "${HDF5_LIBRARIES}")
+
+target_link_libraries(cgadgetron PUBLIC "${FFTW3_LIBRARIES}")
+
 
 ADD_SUBDIRECTORY(tests)

--- a/src/xGadgetron/cGadgetron/tests/CMakeLists.txt
+++ b/src/xGadgetron/cGadgetron/tests/CMakeLists.txt
@@ -18,7 +18,7 @@
 #=========================================================================
 
 add_executable(MR_TESTS_CPLUSPLUS ${CMAKE_CURRENT_SOURCE_DIR}/mrtests.cpp)
-target_link_libraries(MR_TESTS_CPLUSPLUS PUBLIC csirf cgadgetron)
+target_link_libraries(MR_TESTS_CPLUSPLUS PUBLIC cgadgetron)
 INSTALL(TARGETS MR_TESTS_CPLUSPLUS DESTINATION bin)
 
 ADD_TEST(NAME MR_TESTS_CPLUSPLUS


### PR DESCRIPTION
By linking against `ISMRMRD::ISMRMRD`, we also link properly against HDF5, avoiding mismatches with Matlab's HDF5 version.