### PR TITLE
Quck fix for out= problem in PR #606

### DIFF
--- a/examples/Python/MR/acquisition_model.py
+++ b/examples/Python/MR/acquisition_model.py
@@ -60,6 +60,14 @@ def main():
     print('---\n pre-processing acquisition data...')
     processed_data = preprocess_acquisition_data(acq_data)
     print('---\n processed acquisition data norm: %e' % processed_data.norm())
+    pad2 = processed_data - processed_data
+    pad2_arr = pad2.as_array()
+    d = numpy.linalg.norm(pad2_arr)
+    print('acquisitions subtraction error: %.1e' % d)
+    processed_data.subtract(processed_data, out=pad2)
+    pad2_arr = pad2.as_array()
+    d = numpy.linalg.norm(pad2_arr)
+    print('acquisitions subtraction (with out=) error: %.1e' % d)
     pad2 = processed_data * processed_data
     pad_arr = processed_data.as_array()
     pad2_arr = pad2.as_array()
@@ -95,6 +103,14 @@ def main():
     reconstructed_images = recon.get_output()
     r_norm = reconstructed_images.norm()
     print('---\n reconstructed images norm: %e' % r_norm)
+    ri2 = reconstructed_images - reconstructed_images
+    ri2_arr = ri2.as_array()
+    d = numpy.linalg.norm(ri2_arr)
+    print('images subtraction error: %.1e' % d)
+    reconstructed_images.subtract(reconstructed_images, out=ri2)
+    ri2_arr = ri2.as_array()
+    d = numpy.linalg.norm(ri2_arr)
+    print('images subtraction (with out=) error: %.1e' % d)
     ri2 = reconstructed_images * reconstructed_images
     ri_arr = reconstructed_images.as_array()
     ri2_arr = ri2.as_array()

--- a/examples/Python/MR/acquisition_model.py
+++ b/examples/Python/MR/acquisition_model.py
@@ -60,6 +60,13 @@ def main():
     print('---\n pre-processing acquisition data...')
     processed_data = preprocess_acquisition_data(acq_data)
     print('---\n processed acquisition data norm: %e' % processed_data.norm())
+    pad2 = processed_data * processed_data
+    pad_arr = processed_data.as_array()
+    pad2_arr = pad2.as_array()
+    print numpy.linalg.norm(pad2_arr - pad_arr*pad_arr)
+    processed_data.multiply(processed_data, out=pad2)
+    pad2_arr = pad2.as_array()
+    print numpy.linalg.norm(pad2_arr - pad_arr*pad_arr)
 
     # perform reconstruction to obtain a meaningful ImageData object
     # (cannot be obtained in any other way at present)
@@ -75,6 +82,13 @@ def main():
     reconstructed_images = recon.get_output()
     r_norm = reconstructed_images.norm()
     print('---\n reconstructed images norm: %e' % r_norm)
+    ri2 = reconstructed_images * reconstructed_images
+    ri_arr = reconstructed_images.as_array()
+    ri2_arr = ri2.as_array()
+    print numpy.linalg.norm(ri2_arr - ri_arr*ri_arr)
+    reconstructed_images.multiply(reconstructed_images, out=ri2)
+    ri2_arr = ri2.as_array()
+    print numpy.linalg.norm(ri2_arr - ri_arr*ri_arr)
 
     for i in range(min(8, reconstructed_images.number())):
         reconstructed_image = reconstructed_images.image(i)

--- a/examples/Python/MR/acquisition_model.py
+++ b/examples/Python/MR/acquisition_model.py
@@ -63,10 +63,23 @@ def main():
     pad2 = processed_data * processed_data
     pad_arr = processed_data.as_array()
     pad2_arr = pad2.as_array()
-    print numpy.linalg.norm(pad2_arr - pad_arr*pad_arr)
+    d = numpy.linalg.norm(pad2_arr - pad_arr*pad_arr)
+    print('acquisitions multiplication error: %.1e' % d)
     processed_data.multiply(processed_data, out=pad2)
     pad2_arr = pad2.as_array()
-    print numpy.linalg.norm(pad2_arr - pad_arr*pad_arr)
+    d = numpy.linalg.norm(pad2_arr - pad_arr*pad_arr)
+    print('acquisitions multiplication (with out=) error: %.1e' % d)
+    acq = processed_data.copy()
+    pad2_arr[:] = 2.0
+    acq.fill(pad2_arr)
+    pad2 = processed_data / acq
+    pad2_arr = pad2.as_array()
+    d = numpy.linalg.norm(pad2_arr - pad_arr/2)
+    print('acquisitions division error: %.1e' % d)
+    processed_data.divide(acq, out=pad2)
+    pad2_arr = pad2.as_array()
+    d = numpy.linalg.norm(pad2_arr - pad_arr/2)
+    print('acquisitions division (with out=) error: %.1e' % d)
 
     # perform reconstruction to obtain a meaningful ImageData object
     # (cannot be obtained in any other way at present)
@@ -85,14 +98,27 @@ def main():
     ri2 = reconstructed_images * reconstructed_images
     ri_arr = reconstructed_images.as_array()
     ri2_arr = ri2.as_array()
-    print numpy.linalg.norm(ri2_arr - ri_arr*ri_arr)
+    d = numpy.linalg.norm(ri2_arr - ri_arr*ri_arr)
+    print('images multiplication error: %.1e' % d)
     reconstructed_images.multiply(reconstructed_images, out=ri2)
     ri2_arr = ri2.as_array()
-    print numpy.linalg.norm(ri2_arr - ri_arr*ri_arr)
+    d = numpy.linalg.norm(ri2_arr - ri_arr*ri_arr)
+    print('images multiplication (with out=) error: %.1e' % d)
+    img = reconstructed_images.copy()
+    ri2_arr[:] = 2.0
+    img.fill(ri2_arr)
+    ri2 = reconstructed_images / img
+    ri2_arr = ri2.as_array()
+    d = numpy.linalg.norm(ri2_arr - ri_arr/2)
+    print('images division error: %.1e' % d)
+    reconstructed_images.divide(img, out=ri2)
+    ri2_arr = ri2.as_array()
+    d = numpy.linalg.norm(ri2_arr - ri_arr/2)
+    print('images division (with out=) error: %.1e' % d)
 
     for i in range(min(8, reconstructed_images.number())):
         reconstructed_image = reconstructed_images.image(i)
-        print('--- image %d' % i)
+        print('\n--- image %d' % i)
         for p in [ \
             'version', 'flags', 'data_type', 'channels', \
             'slice', 'repetition', \
@@ -106,7 +132,7 @@ def main():
         print(reconstructed_image.patient_table_position())
 
     ind = reconstructed_images.get_info('image_index')
-    print('image indices:')
+    print('\nimage indices:')
     print(ind)
     ind = reconstructed_images.get_info('slice')
     print('image slices:')

--- a/examples/Python/PET/acquisition_data.py
+++ b/examples/Python/PET/acquisition_data.py
@@ -109,6 +109,13 @@ def main():
     acq_copy.fill(acq_data)
     diff = acq_copy - acq_data
     print('norm of acq_copy - acq_data: %f' % diff.norm())
+    pad2 = acq_data * acq_data
+    pad_arr = acq_data.as_array()
+    pad2_arr = pad2.as_array()
+    print numpy.linalg.norm(pad2_arr - pad_arr*pad_arr)
+    acq_data.multiply(acq_data, out=pad2)
+    pad2_arr = pad2.as_array()
+    print numpy.linalg.norm(pad2_arr - pad_arr*pad_arr)
 
     # display the scaled data
     new_acq_data.show(range(dim[1]//4), title = 'Scaled acquisition data')
@@ -131,6 +138,13 @@ def main():
     image_copy.fill(image)
     diff = image_copy - image
     print('norm of image_copy - image: %f' % diff.norm())
+    im2 = image * image
+    im_arr = image.as_array()
+    im2_arr = im2.as_array()
+    print numpy.linalg.norm(im2_arr - im_arr * im_arr)
+    image.multiply(image, out=im2)
+    im2_arr = im2.as_array()
+    print numpy.linalg.norm(im2_arr - im_arr * im_arr)
 
     print('image voxel sizes:')
     print(image.voxel_sizes())

--- a/examples/Python/PET/acquisition_data.py
+++ b/examples/Python/PET/acquisition_data.py
@@ -109,6 +109,14 @@ def main():
     acq_copy.fill(acq_data)
     diff = acq_copy - acq_data
     print('norm of acq_copy - acq_data: %f' % diff.norm())
+    pad2 = acq_data - acq_copy
+    pad2_arr = pad2.as_array()
+    d = numpy.linalg.norm(pad2_arr)
+    print('acquisitions subtraction error: %.1e' % d)
+    acq_data.subtract(acq_copy, out=pad2)
+    pad2_arr = pad2.as_array()
+    d = numpy.linalg.norm(pad2_arr)
+    print('acquisitions subtraction (with out=) error: %.1e' % d)
     pad2 = acq_data * acq_data
     pad_arr = acq_data.as_array()
     pad2_arr = pad2.as_array()
@@ -150,6 +158,14 @@ def main():
     image_copy.fill(image)
     diff = image_copy - image
     print('norm of image_copy - image: %f' % diff.norm())
+    im2 = image - image_copy
+    im2_arr = im2.as_array()
+    d = numpy.linalg.norm(im2_arr)
+    print('images subtraction error: %.1e' % d)
+    image.subtract(image_copy, out=im2)
+    im2_arr = im2.as_array()
+    d = numpy.linalg.norm(im2_arr)
+    print('images subtraction (with out=) error: %.1e' % d)
     im2 = image * image
     im_arr = image.as_array()
     im2_arr = im2.as_array()

--- a/examples/Python/PET/acquisition_data.py
+++ b/examples/Python/PET/acquisition_data.py
@@ -112,10 +112,22 @@ def main():
     pad2 = acq_data * acq_data
     pad_arr = acq_data.as_array()
     pad2_arr = pad2.as_array()
-    print numpy.linalg.norm(pad2_arr - pad_arr*pad_arr)
+    d = numpy.linalg.norm(pad2_arr - pad_arr*pad_arr)
+    print('acquisitions multiplication error: %.1e' % d)
     acq_data.multiply(acq_data, out=pad2)
     pad2_arr = pad2.as_array()
-    print numpy.linalg.norm(pad2_arr - pad_arr*pad_arr)
+    d = numpy.linalg.norm(pad2_arr - pad_arr*pad_arr)
+    print('acquisitions multiplication (with out=) error: %.1e' % d)
+    pad2_arr[:] = 2.0
+    acq_copy.fill(pad2_arr)
+    pad2 = acq_data / acq_copy
+    pad2_arr = pad2.as_array()
+    d = numpy.linalg.norm(pad2_arr - pad_arr/2)
+    print('acquisitions division error: %.1e' % d)
+    acq_data.divide(acq_copy, out=pad2)
+    pad2_arr = pad2.as_array()
+    d = numpy.linalg.norm(pad2_arr - pad_arr/2)
+    print('acquisitions division (with out=) error: %.1e' % d)
 
     # display the scaled data
     new_acq_data.show(range(dim[1]//4), title = 'Scaled acquisition data')
@@ -141,10 +153,22 @@ def main():
     im2 = image * image
     im_arr = image.as_array()
     im2_arr = im2.as_array()
-    print numpy.linalg.norm(im2_arr - im_arr * im_arr)
+    d = numpy.linalg.norm(im2_arr - im_arr * im_arr)
+    print('images multiplication error: %.1e' % d)
     image.multiply(image, out=im2)
     im2_arr = im2.as_array()
-    print numpy.linalg.norm(im2_arr - im_arr * im_arr)
+    d = numpy.linalg.norm(im2_arr - im_arr * im_arr)
+    print('images multiplication (with out=) error: %.1e' % d)
+    im2_arr[:] = 2.0
+    image_copy.fill(im2_arr)
+    im2 = image / image_copy
+    im2_arr = im2.as_array()
+    d = numpy.linalg.norm(im2_arr - im_arr/2)
+    print('images division error: %.1e' % d)
+    image.divide(image_copy, out=im2)
+    im2_arr = im2.as_array()
+    d = numpy.linalg.norm(im2_arr - im_arr/2)
+    print('images division (with out=) error: %.1e' % d)
 
     print('image voxel sizes:')
     print(image.voxel_sizes())

--- a/src/common/SIRF.py
+++ b/src/common/SIRF.py
@@ -117,10 +117,13 @@ class DataContainer(ABC):
             other.fill(tmp)
         assert_validities(self, other)
         if out is None:
-            out = self.copy()
+            out = self.same_object()
+            out.handle = pysirf.cSIRF_product(self.handle, other.handle)
+            check_status(out.handle)
+            #out = self.copy()
         else:
             assert_validities(self, out)
-        try_calling(pysirf.cSIRF_multiply(self.handle, other.handle, out.handle))
+            try_calling(pysirf.cSIRF_multiply(self.handle, other.handle, out.handle))
         return out
     def divide(self, other, out=None):
         '''

--- a/src/common/SIRF.py
+++ b/src/common/SIRF.py
@@ -163,12 +163,14 @@ class DataContainer(ABC):
         one = numpy.asarray([1.0, 0.0], dtype = numpy.float32)
         if out is None:
             z = self.same_object()
+            z.handle = pysirf.cSIRF_axpby \
+                (one.ctypes.data, self.handle, one.ctypes.data, other.handle)
+            check_status(z.handle)
         else:
             assert_validities(self, out)
             z = out
-        z.handle = pysirf.cSIRF_axpby \
-            (one.ctypes.data, self.handle, one.ctypes.data, other.handle)
-        check_status(z.handle)
+            try_calling(pysirf.cSIRF_axpbyAlt \
+                (one.ctypes.data, self.handle, one.ctypes.data, other.handle, z.handle))
         return z
     def axpby(self, a,b, y, out=None, **kwargs):
         '''
@@ -229,12 +231,14 @@ class DataContainer(ABC):
         mn_one = numpy.asarray([-1.0, 0.0], dtype = numpy.float32)
         if out is None:
             z = self.same_object()
+            z.handle = pysirf.cSIRF_axpby \
+                (pl_one.ctypes.data, self.handle, mn_one.ctypes.data, other.handle)
+            check_status(z.handle)
         else:
             assert_validities(self, out)
             z = out
-        z.handle = pysirf.cSIRF_axpby \
-            (pl_one.ctypes.data, self.handle, mn_one.ctypes.data, other.handle)
-        check_status(z.handle)
+            try_calling(pysirf.cSIRF_axpbyAlt \
+                (pl_one.ctypes.data, self.handle, mn_one.ctypes.data, other.handle, z.handle))
         return z
     def __sub__(self, other):
         '''

--- a/src/common/SIRF.py
+++ b/src/common/SIRF.py
@@ -138,10 +138,13 @@ class DataContainer(ABC):
             other.fill(tmp)
         assert_validities(self, other)
         if out is None:
-            out = self.copy()
+            out = self.same_object()
+            out.handle = pysirf.cSIRF_ratio(self.handle, other.handle)
+            check_status(out.handle)
+            #out = self.copy()
         else:
             assert_validities(self, out)
-        try_calling(pysirf.cSIRF_divide(self.handle, other.handle, out.handle))
+            try_calling(pysirf.cSIRF_divide(self.handle, other.handle, out.handle))
         return out
     def add(self, other, out=None):
         '''

--- a/src/common/csirf.cpp
+++ b/src/common/csirf.cpp
@@ -144,6 +144,23 @@ cSIRF_multiply(const void* ptr_x, const void* ptr_y, const void* ptr_z)
 
 extern "C"
 void*
+cSIRF_product(const void* ptr_x, const void* ptr_y)
+{
+	try {
+		DataContainer& x =
+			objectFromHandle<DataContainer >(ptr_x);
+		DataContainer& y =
+			objectFromHandle<DataContainer >(ptr_y);
+		void* h = x.new_data_container_handle();
+		DataContainer& z = objectFromHandle<DataContainer>(h);
+		z.multiply(x, y);
+		return h;
+	}
+	CATCH;
+}
+
+extern "C"
+void*
 cSIRF_divide(const void* ptr_x, const void* ptr_y, const void* ptr_z)
 {
 	try {

--- a/src/common/csirf.cpp
+++ b/src/common/csirf.cpp
@@ -118,9 +118,26 @@ const void* ptr_b, const void* ptr_y
 		DataContainer& z = objectFromHandle<DataContainer>(h);
 		z.axpby(ptr_a, x, ptr_b, y);
 		return h;
-		//shared_ptr<DataContainer > sptr_z(x.new_data_container());
-		//sptr_z->axpby(ptr_a, x, ptr_b, y);
-		//return newObjectHandle<DataContainer >(sptr_z);
+	}
+	CATCH;
+}
+
+extern "C"
+void*
+cSIRF_axpbyAlt(
+const void* ptr_a, const void* ptr_x,
+const void* ptr_b, const void* ptr_y,
+void* ptr_z
+) {
+	try {
+		DataContainer& x =
+			objectFromHandle<DataContainer >(ptr_x);
+		DataContainer& y =
+			objectFromHandle<DataContainer >(ptr_y);
+		DataContainer& z =
+			objectFromHandle<DataContainer >(ptr_z);
+		z.axpby(ptr_a, x, ptr_b, y);
+		return new DataHandle;
 	}
 	CATCH;
 }

--- a/src/common/csirf.cpp
+++ b/src/common/csirf.cpp
@@ -178,6 +178,23 @@ cSIRF_divide(const void* ptr_x, const void* ptr_y, const void* ptr_z)
 
 extern "C"
 void*
+cSIRF_ratio(const void* ptr_x, const void* ptr_y)
+{
+	try {
+		DataContainer& x =
+			objectFromHandle<DataContainer >(ptr_x);
+		DataContainer& y =
+			objectFromHandle<DataContainer >(ptr_y);
+		void* h = x.new_data_container_handle();
+		DataContainer& z = objectFromHandle<DataContainer>(h);
+		z.divide(x, y);
+		return h;
+	}
+	CATCH;
+}
+
+extern "C"
+void*
 cSIRF_write(const void* ptr, const char* filename)
 {
 	try {
@@ -231,7 +248,7 @@ void* cSIRF_ImageData_reorient(void* im_ptr, void *geom_info_ptr)
         id.reorient(geom_info);
         return new DataHandle;
     }
-    CATCH
+    CATCH;
 }
 
 extern "C"

--- a/src/common/include/sirf/common/csirf.h
+++ b/src/common/include/sirf/common/csirf.h
@@ -44,6 +44,7 @@ void* cSIRF_axpby(const PTR_FLOAT ptr_a, const void* ptr_x,
 void* cSIRF_multiply(const void* ptr_x, const void* ptr_y, const void* ptr_z);
 void* cSIRF_product(const void* ptr_x, const void* ptr_y);
 void* cSIRF_divide(const void* ptr_x, const void* ptr_y, const void* ptr_z);
+void* cSIRF_ratio(const void* ptr_x, const void* ptr_y);
 void* cSIRF_write(const void* ptr, const char* filename);
 void* cSIRF_clone(void* ptr_x);
 

--- a/src/common/include/sirf/common/csirf.h
+++ b/src/common/include/sirf/common/csirf.h
@@ -42,6 +42,7 @@ void* cSIRF_dot(const void* ptr_x, const void* ptr_y);
 void* cSIRF_axpby(const PTR_FLOAT ptr_a, const void* ptr_x,
 	const PTR_FLOAT ptr_b, const void* ptr_y);
 void* cSIRF_multiply(const void* ptr_x, const void* ptr_y, const void* ptr_z);
+void* cSIRF_product(const void* ptr_x, const void* ptr_y);
 void* cSIRF_divide(const void* ptr_x, const void* ptr_y, const void* ptr_z);
 void* cSIRF_write(const void* ptr, const char* filename);
 void* cSIRF_clone(void* ptr_x);

--- a/src/common/include/sirf/common/csirf.h
+++ b/src/common/include/sirf/common/csirf.h
@@ -41,6 +41,8 @@ void* cSIRF_norm(const void* ptr_x);
 void* cSIRF_dot(const void* ptr_x, const void* ptr_y);
 void* cSIRF_axpby(const PTR_FLOAT ptr_a, const void* ptr_x,
 	const PTR_FLOAT ptr_b, const void* ptr_y);
+void* cSIRF_axpbyAlt(const PTR_FLOAT ptr_a, const void* ptr_x,
+	const PTR_FLOAT ptr_b, const void* ptr_y, void* ptr_z);
 void* cSIRF_multiply(const void* ptr_x, const void* ptr_y, const void* ptr_z);
 void* cSIRF_product(const void* ptr_x, const void* ptr_y);
 void* cSIRF_divide(const void* ptr_x, const void* ptr_y, const void* ptr_z);

--- a/src/xGadgetron/cGadgetron/gadgetron_data_containers.cpp
+++ b/src/xGadgetron/cGadgetron/gadgetron_data_containers.cpp
@@ -370,16 +370,15 @@ MRAcquisitionData::multiply(
 const DataContainer& a_x,
 const DataContainer& a_y)
 {
-	//MRAcquisitionData& x = (MRAcquisitionData&)a_x;
-	//MRAcquisitionData& y = (MRAcquisitionData&)a_y;
 	DYNAMIC_CAST(const MRAcquisitionData, x, a_x);
 	DYNAMIC_CAST(const MRAcquisitionData, y, a_y);
 	int m = x.number();
 	int n = y.number();
 	ISMRMRD::Acquisition ax;
 	ISMRMRD::Acquisition ay;
-	if (number() > 0)
+	if (number() > 0) {
 		empty();
+	}
 	for (int i = 0, j = 0; i < n && j < m;) {
 		y.get_acquisition(i, ay);
 		x.get_acquisition(j, ax);
@@ -954,8 +953,6 @@ GadgetronImageData::multiply(
 const DataContainer& a_x,
 const DataContainer& a_y)
 {
-	//GadgetronImageData& x = (GadgetronImageData&)a_x;
-	//GadgetronImageData& y = (GadgetronImageData&)a_y;
 	DYNAMIC_CAST(const GadgetronImageData, x, a_x);
 	DYNAMIC_CAST(const GadgetronImageData, y, a_y);
 	unsigned int nx = x.number();

--- a/src/xGadgetron/cGadgetron/gadgetron_data_containers.cpp
+++ b/src/xGadgetron/cGadgetron/gadgetron_data_containers.cpp
@@ -412,6 +412,9 @@ const DataContainer& a_y)
 	int n = y.number();
 	ISMRMRD::Acquisition ax;
 	ISMRMRD::Acquisition ay;
+	if (number() > 0) {
+		empty();
+	}
 	for (int i = 0, j = 0; i < n && j < m;) {
 		y.get_acquisition(i, ay);
 		x.get_acquisition(j, ax);
@@ -981,8 +984,35 @@ GadgetronImageData::divide(
 const DataContainer& a_x,
 const DataContainer& a_y)
 {
-	//GadgetronImageData& x = (GadgetronImageData&)a_x;
-	//GadgetronImageData& y = (GadgetronImageData&)a_y;
+	DYNAMIC_CAST(const GadgetronImageData, x, a_x);
+	DYNAMIC_CAST(const GadgetronImageData, y, a_y);
+	unsigned int nx = x.number();
+	unsigned int ny = y.number();
+	if (nx != ny)
+		THROW("ImageData sizes mismatch in multiply");
+	unsigned int n = number();
+	if (n > 0) {
+		if (n != nx)
+			THROW("ImageData sizes mismatch in multiply");
+		for (unsigned int i = 0; i < nx && i < ny; i++)
+			image_wrap(i).divide(x.image_wrap(i), y.image_wrap(i));
+	}
+	else {
+		for (unsigned int i = 0; i < nx && i < ny; i++) {
+			ImageWrap w(x.image_wrap(i));
+			w.divide(y.image_wrap(i));
+			append(w);
+		}
+	}
+	this->set_meta_data(x.get_meta_data());
+}
+
+/*
+void
+GadgetronImageData::divide(
+const DataContainer& a_x,
+const DataContainer& a_y)
+{
 	DYNAMIC_CAST(const GadgetronImageData, x, a_x);
 	DYNAMIC_CAST(const GadgetronImageData, y, a_y);
 	for (unsigned int i = 0; i < x.number() && i < y.number(); i++) {
@@ -992,7 +1022,7 @@ const DataContainer& a_y)
 	}
 	this->set_meta_data(x.get_meta_data());
 }
-
+*/
 float 
 GadgetronImageData::norm() const
 {

--- a/src/xGadgetron/cGadgetron/gadgetron_data_containers.cpp
+++ b/src/xGadgetron/cGadgetron/gadgetron_data_containers.cpp
@@ -958,12 +958,23 @@ const DataContainer& a_y)
 	//GadgetronImageData& y = (GadgetronImageData&)a_y;
 	DYNAMIC_CAST(const GadgetronImageData, x, a_x);
 	DYNAMIC_CAST(const GadgetronImageData, y, a_y);
-	if (number() > 0)
-		empty();
-	for (unsigned int i = 0; i < x.number() && i < y.number(); i++) {
-		ImageWrap w(x.image_wrap(i));
-		w.multiply(y.image_wrap(i));
-		append(w);
+	unsigned int nx = x.number();
+	unsigned int ny = y.number();
+	if (nx != ny)
+		THROW("ImageData sizes mismatch in multiply");
+	unsigned int n = number();
+	if (n > 0) {
+		if (n != nx)
+			THROW("ImageData sizes mismatch in multiply");
+		for (unsigned int i = 0; i < nx && i < ny; i++)
+			image_wrap(i).multiply(x.image_wrap(i), y.image_wrap(i));
+	}
+	else {
+		for (unsigned int i = 0; i < nx && i < ny; i++) {
+			ImageWrap w(x.image_wrap(i));
+			w.multiply(y.image_wrap(i));
+			append(w);
+		}
 	}
 	this->set_meta_data(x.get_meta_data());
 }

--- a/src/xGadgetron/cGadgetron/include/sirf/Gadgetron/gadgetron_data_containers.h
+++ b/src/xGadgetron/cGadgetron/include/sirf/Gadgetron/gadgetron_data_containers.h
@@ -318,6 +318,12 @@ namespace sirf {
 
 		virtual MRAcquisitionData* clone_impl() const = 0;
 		MRAcquisitionData* clone_base() const;
+
+	private:
+		void binary_op_(int op, 
+			const MRAcquisitionData& a_x, const MRAcquisitionData& a_y,
+			complex_float_t a = 0, complex_float_t b = 0);
+
 	};
 
 	/*!
@@ -368,7 +374,8 @@ namespace sirf {
 		virtual void get_acquisition(unsigned int num, ISMRMRD::Acquisition& acq) const;
 		virtual void set_acquisition(unsigned int num, ISMRMRD::Acquisition& acq)
 		{
-			std::cerr << "AcquisitionsFile::set_acquisition not implemented yet, sorry\n";
+			//std::cerr << 
+			THROW("AcquisitionsFile::set_acquisition not implemented yet, sorry\n");
 		}
 		virtual void append_acquisition(ISMRMRD::Acquisition& acq);
 		virtual void copy_acquisitions_info(const MRAcquisitionData& ac);

--- a/src/xGadgetron/cGadgetron/include/sirf/Gadgetron/gadgetron_data_containers.h
+++ b/src/xGadgetron/cGadgetron/include/sirf/Gadgetron/gadgetron_data_containers.h
@@ -221,6 +221,8 @@ namespace sirf {
 
 		// abstract methods
 
+		virtual void empty() = 0;
+
 		// the number of acquisitions in the container
 		virtual unsigned int number() const = 0;
 
@@ -359,6 +361,7 @@ namespace sirf {
 
 		// implementations of abstract methods
 
+		virtual void empty();
 		virtual void set_data(const complex_float_t* z, int all = 1);
 		virtual unsigned int items() const;
 		virtual unsigned int number() const { return items(); }
@@ -425,6 +428,7 @@ namespace sirf {
 			acqs_templ_.reset(new AcquisitionsVector);
 			_storage_scheme = "memory";
 		}
+		virtual void empty();
 		virtual unsigned int number() const { return (unsigned int)acqs_.size(); }
 		virtual unsigned int items() const { return (unsigned int)acqs_.size(); }
 		virtual void append_acquisition(ISMRMRD::Acquisition& acq)
@@ -489,7 +493,7 @@ namespace sirf {
 		//ISMRMRDImageData(ISMRMRDImageData& id, const char* attr, 
 		//const char* target); //does not build, have to be in the derived class
 		
-
+		virtual void empty() = 0;
 		virtual unsigned int number() const = 0;
 		virtual gadgetron::shared_ptr<ImageWrap> sptr_image_wrap
 			(unsigned int im_num) = 0;
@@ -747,6 +751,10 @@ namespace sirf {
         GadgetronImagesVector(const GadgetronImagesVector& images);
 		GadgetronImagesVector(GadgetronImagesVector& images, const char* attr,
 			const char* target);
+		virtual void empty()
+		{
+			images_.clear();
+		}
 		virtual unsigned int items() const
 		{ 
 			return (unsigned int)images_.size(); 

--- a/src/xGadgetron/cGadgetron/include/sirf/Gadgetron/gadgetron_image_wrap.h
+++ b/src/xGadgetron/cGadgetron/include/sirf/Gadgetron/gadgetron_image_wrap.h
@@ -410,6 +410,10 @@ namespace sirf {
 		{
 			IMAGE_PROCESSING_SWITCH(type_, multiply_, x.ptr_image());
 		}
+		void multiply(const ImageWrap& x, const ImageWrap& y)
+		{
+			IMAGE_PROCESSING_SWITCH(type_, multiply__, x.ptr_image(), y.ptr_image());
+		}
 		void divide(const ImageWrap& x)
 		{
 			IMAGE_PROCESSING_SWITCH(type_, divide_, x.ptr_image());
@@ -629,6 +633,27 @@ namespace sirf {
 				complex_float_t u = (complex_float_t)*i;
 				complex_float_t v = (complex_float_t)*j;
 				xGadgetronUtilities::convert_complex(u*v, *j);
+			}
+		}
+
+		template<typename T>
+		void multiply__(const ISMRMRD::Image<T>* ptr_x, const void* vptr_y)
+		{
+			ISMRMRD::Image<T>* ptr = (ISMRMRD::Image<T>*)ptr_;
+			ISMRMRD::Image<T>* ptr_y = (ISMRMRD::Image<T>*)vptr_y;
+			size_t nx = ptr_x->getNumberOfDataElements();
+			size_t ny = ptr_y->getNumberOfDataElements();
+			size_t n = ptr->getNumberOfDataElements();
+			if (!(n == nx && n == ny))
+				THROW("sizes mismatch in ImageWrap multiply");
+			const T* i = ptr_x->getDataPtr();
+			const T* j = ptr_y->getDataPtr();
+			T* k = ptr->getDataPtr();
+			size_t ii = 0;
+			for (; ii < n; i++, j++, k++, ii++) {
+				complex_float_t u = (complex_float_t)*i;
+				complex_float_t v = (complex_float_t)*j;
+				xGadgetronUtilities::convert_complex(u*v, *k);
 			}
 		}
 

--- a/src/xGadgetron/cGadgetron/include/sirf/Gadgetron/gadgetron_image_wrap.h
+++ b/src/xGadgetron/cGadgetron/include/sirf/Gadgetron/gadgetron_image_wrap.h
@@ -418,6 +418,10 @@ namespace sirf {
 		{
 			IMAGE_PROCESSING_SWITCH(type_, divide_, x.ptr_image());
 		}
+		void divide(const ImageWrap& x, const ImageWrap& y)
+		{
+			IMAGE_PROCESSING_SWITCH(type_, divide__, x.ptr_image(), y.ptr_image());
+		}
 		complex_float_t dot(const ImageWrap& iw) const
 		{
 			complex_float_t z;
@@ -624,12 +628,14 @@ namespace sirf {
 		void multiply_(const ISMRMRD::Image<T>* ptr_x)
 		{
 			ISMRMRD::Image<T>* ptr_y = (ISMRMRD::Image<T>*)ptr_;
-			const T* i;
-			T* j;
+			size_t nx = ptr_x->getNumberOfDataElements();
+			size_t ny = ptr_y->getNumberOfDataElements();
+			if (nx != ny)
+				THROW("sizes mismatch in ImageWrap multiply");
+			const T* i = ptr_x->getDataPtr();
+			T* j = ptr_y->getDataPtr();
 			size_t ii = 0;
-			size_t n = ptr_x->getNumberOfDataElements();
-			for (i = ptr_x->getDataPtr(), j = ptr_y->getDataPtr(); ii < n;
-				i++, j++, ii++) {
+			for (; ii < nx; i++, j++, ii++) {
 				complex_float_t u = (complex_float_t)*i;
 				complex_float_t v = (complex_float_t)*j;
 				xGadgetronUtilities::convert_complex(u*v, *j);
@@ -661,16 +667,40 @@ namespace sirf {
 		void divide_(const ISMRMRD::Image<T>* ptr_x)
 		{
 			ISMRMRD::Image<T>* ptr_y = (ISMRMRD::Image<T>*)ptr_;
-			const T* i;
-			T* j;
+			size_t nx = ptr_x->getNumberOfDataElements();
+			size_t ny = ptr_y->getNumberOfDataElements();
+			if (nx != ny)
+				THROW("sizes mismatch in ImageWrap multiply");
+			const T* i = ptr_x->getDataPtr();
+			T* j = ptr_y->getDataPtr();
 			size_t ii = 0;
-			size_t n = ptr_x->getNumberOfDataElements();
-			for (i = ptr_x->getDataPtr(), j = ptr_y->getDataPtr(); ii < n;
-				i++, j++, ii++) {
+			for (; ii < nx; i++, j++, ii++) {
 				complex_float_t u = (complex_float_t)*i;
 				complex_float_t v = (complex_float_t)*j;
 				// TODO: check for zero denominator
-				xGadgetronUtilities::convert_complex(u / v, *j);
+				xGadgetronUtilities::convert_complex(v / u, *j);
+			}
+		}
+
+		template<typename T>
+		void divide__(const ISMRMRD::Image<T>* ptr_x, const void* vptr_y)
+		{
+			ISMRMRD::Image<T>* ptr = (ISMRMRD::Image<T>*)ptr_;
+			ISMRMRD::Image<T>* ptr_y = (ISMRMRD::Image<T>*)vptr_y;
+			size_t nx = ptr_x->getNumberOfDataElements();
+			size_t ny = ptr_y->getNumberOfDataElements();
+			size_t n = ptr->getNumberOfDataElements();
+			if (!(n == nx && n == ny))
+				THROW("sizes mismatch in ImageWrap multiply");
+			const T* i = ptr_x->getDataPtr();
+			const T* j = ptr_y->getDataPtr();
+			T* k = ptr->getDataPtr();
+			size_t ii = 0;
+			for (; ii < n; i++, j++, k++, ii++) {
+				complex_float_t u = (complex_float_t)*i;
+				complex_float_t v = (complex_float_t)*j;
+				// TODO: check for zero denominator
+				xGadgetronUtilities::convert_complex(u / v, *k);
 			}
 		}
 


### PR DESCRIPTION
A proper fix of the use of `out=` requires overwriting data in data containers, and hence, in particular, the ability to modify data in the existing HDF5 file, which might need considerable effort (not so much in coding but rather in cross-platform building - I for one still cannot run MR Python demos on Windows).

Meanwhile I suggest a simple quick fix for MR acquisitions (the rest of data have no problems with working with `out=`), whereby I, following Pythonesque style, `try` to overwrite data in `MRAcquisitionData`, and if that throws, erase existing data and put new data via `append` (this is what `fill` method does anyway).